### PR TITLE
Increase MQTT reliability across modules

### DIFF
--- a/event-storage/src/main.rs
+++ b/event-storage/src/main.rs
@@ -1,10 +1,9 @@
-
-use std::env;
-use std::time::Duration;
 use ava_toolkit::domotic_factory::DomoticFactory;
 use log::*;
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, MqttOptions};
+use std::env;
+use std::time::Duration;
 
 use crate::message_enum::MessageEnum;
 use ava_toolkit::hard_loop::HardLoop;
@@ -33,31 +32,41 @@ fn read_props_or_die(property_name: &str) -> String {
 /// By default, the program will look for the .doka-config.json file in the user's base folder
 #[tokio::main]
 async fn main() {
-
-    env::set_var("RUST_LOG", env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()));
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init();
 
     info!("Starting AVA event-storage 0.5.0");
-    
+
     const PROJECT_CODE: &str = "event-storage";
     const VAR_NAME: &str = "AVA_ENV";
 
     let o_config_file = read_env(&VAR_NAME);
 
     // Read the application config's file
-    println!("😎 Config file using PROJECT_CODE={} VAR_NAME={}", PROJECT_CODE, VAR_NAME);
+    println!(
+        "😎 Config file using PROJECT_CODE={} VAR_NAME={}",
+        PROJECT_CODE, VAR_NAME
+    );
 
-    let props = read_config(PROJECT_CODE, &o_config_file, &Some("AVA_CLUSTER_PROFILE".to_string()));
+    let props = read_config(
+        PROJECT_CODE,
+        &o_config_file,
+        &Some("AVA_CLUSTER_PROFILE".to_string()),
+    );
     set_prop_values(props);
 
     let factory_message_dir = read_props_or_die("factory.dir");
     let module_file = read_props_or_die("module");
-    let mqtt_port = read_props_or_die("mqtt.port").parse::<u16>().unwrap(); // TODO 
+    let mqtt_port = read_props_or_die("mqtt.port").parse::<u16>().unwrap(); // TODO
     let mqtt_user = read_props_or_die("mqtt.user");
     let mqtt_password = read_props_or_die("mqtt.password");
     let mqtt_host = read_props_or_die("mqtt.host");
-    
-    let mut domo_factory: DomoticFactory<MessageEnum> = DomoticFactory::new(module_file, factory_message_dir);
+
+    let mut domo_factory: DomoticFactory<MessageEnum> =
+        DomoticFactory::new(module_file, factory_message_dir);
     domo_factory.build_devices();
 
     let all_loops = domo_factory.build_loops();
@@ -72,16 +81,17 @@ async fn main() {
     mqttoptions.set_clean_start(true);
     mqttoptions.set_credentials(mqtt_user, mqtt_password);
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 100);
 
     for p in &channels.channel_filters {
         info!("Subscribe to [{}]", p.0);
-        client.subscribe(p.0.clone(), QoS::AtMostOnce).await.unwrap();
+        client
+            .subscribe(p.0.clone(), QoS::AtLeastOnce)
+            .await
+            .unwrap();
     }
 
-    let loop_finder = |topic: &str| {
-        HardLoop::find_loops(topic, &all_loops)
-    };
+    let loop_finder = |topic: &str| HardLoop::find_loops(topic, &all_loops);
 
     match process_initialization_message(&mut client, &mut eventloop, &init_list).await {
         Ok(_) => {
@@ -94,6 +104,3 @@ async fn main() {
     }
     println!("Done!");
 }
-
-
-

--- a/luminator/src/main.rs
+++ b/luminator/src/main.rs
@@ -1,4 +1,3 @@
-
 use std::env;
 
 use std::time::Duration;
@@ -9,19 +8,20 @@ use ava_toolkit::domotic_factory::DomoticFactory;
 use ava_toolkit::hard_loop::HardLoop;
 use ava_toolkit::init_loop::process_initialization_message;
 use ava_toolkit::processing::process_incoming_message;
+use common_config::conf_reader::{read_config, read_env};
+use common_config::properties::{get_prop_value, set_prop_values};
 use log::{error, info};
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, MqttOptions};
-use common_config::conf_reader::{read_config, read_env};
-use common_config::properties::{get_prop_value, set_prop_values};
 
 mod message_enum;
 
-
 #[tokio::main]
 async fn main() {
-
-    env::set_var("RUST_LOG", env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()));
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init();
 
     info!("Starting AVA luminator 0.5.0");
@@ -32,9 +32,16 @@ async fn main() {
     let o_config_file = read_env(&VAR_NAME);
 
     // Read the application config's file
-    println!("😎 Config file using PROJECT_CODE={} VAR_NAME={}", PROJECT_CODE, VAR_NAME);
+    println!(
+        "😎 Config file using PROJECT_CODE={} VAR_NAME={}",
+        PROJECT_CODE, VAR_NAME
+    );
 
-    let props = read_config(PROJECT_CODE, &o_config_file, &Some("AVA_CLUSTER_PROFILE".to_string()));
+    let props = read_config(
+        PROJECT_CODE,
+        &o_config_file,
+        &Some("AVA_CLUSTER_PROFILE".to_string()),
+    );
     set_prop_values(props);
 
     let factory_message_dir = read_props_or_die("factory.dir");
@@ -44,32 +51,35 @@ async fn main() {
     let mqtt_password = read_props_or_die("mqtt.password");
     let mqtt_host = read_props_or_die("mqtt.host");
 
-    let mut domo_factory: DomoticFactory<MessageEnum> = DomoticFactory::new(module_file, factory_message_dir);
+    let mut domo_factory: DomoticFactory<MessageEnum> =
+        DomoticFactory::new(module_file, factory_message_dir);
     domo_factory.build_devices();
-    
+
     let all_loops = domo_factory.build_loops();
     let init_list = domo_factory.devices_to_init();
     let device_to_listen = domo_factory.devices_to_listen();
 
     let args: Vec<String> = vec![];
-    let channels = DomoticFactory::extract_channel_from_devices(&device_to_listen, mqtt_host.as_str());
-    
+    let channels =
+        DomoticFactory::extract_channel_from_devices(&device_to_listen, mqtt_host.as_str());
+
     let mut mqttoptions = MqttOptions::new(&channels.client_id, &channels.server_addr, mqtt_port);
     mqttoptions.set_keep_alive(Duration::from_secs(channels.keep_alive as u64));
     mqttoptions.set_clean_start(true);
     mqttoptions.set_credentials(mqtt_user, mqtt_password);
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 100);
 
     for p in &channels.channel_filters {
         info!("Subscribe to [{}]", p.0);
-        client.subscribe(p.0.clone(), QoS::AtMostOnce).await.unwrap();
+        client
+            .subscribe(p.0.clone(), QoS::AtLeastOnce)
+            .await
+            .unwrap();
     }
-    
-    let loop_finder = |topic: &str| {
-        HardLoop::find_loops(topic, &all_loops)
-    };
-    
+
+    let loop_finder = |topic: &str| HardLoop::find_loops(topic, &all_loops);
+
     match process_initialization_message(&mut client, &mut eventloop, &init_list).await {
         Ok(_) => {
             info!("Process incoming messages");
@@ -92,4 +102,3 @@ fn read_props_or_die(property_name: &str) -> String {
     };
     value
 }
-

--- a/mqtt-bridge/src/main.rs
+++ b/mqtt-bridge/src/main.rs
@@ -1,16 +1,24 @@
 use std::{env, net::SocketAddr, time::Duration};
 
-use futures_util::{SinkExt, StreamExt};
 use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt, StreamExt};
 use log::*;
-use rumqttc::v5::{AsyncClient, Event, EventLoop, Incoming, MqttOptions};
 use rumqttc::v5::mqttbytes::QoS;
-use tokio::net::{TcpListener, TcpStream};
-use tokio_tungstenite::{accept_async, tungstenite::{Error, Message, Result}, WebSocketStream};
-use uuid::Uuid;
+use rumqttc::v5::{AsyncClient, Event, EventLoop, Incoming, MqttOptions};
 use serde::{Deserialize, Serialize};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{
+    accept_async,
+    tungstenite::{Error, Message, Result},
+    WebSocketStream,
+};
+use uuid::Uuid;
 
-async fn accept_connection_for_writing_ws(peer: SocketAddr, stream: SplitSink<WebSocketStream<TcpStream>, Message>, eventloop: EventLoop) {
+async fn accept_connection_for_writing_ws(
+    peer: SocketAddr,
+    stream: SplitSink<WebSocketStream<TcpStream>, Message>,
+    eventloop: EventLoop,
+) {
     if let Err(e) = handle_writing_ws(peer, stream, eventloop).await {
         match e {
             Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
@@ -19,7 +27,11 @@ async fn accept_connection_for_writing_ws(peer: SocketAddr, stream: SplitSink<We
     }
 }
 
-async fn accept_connection_for_reading_ws(peer: SocketAddr, ws_receiver: SplitStream<WebSocketStream<TcpStream>>, client: AsyncClient) {
+async fn accept_connection_for_reading_ws(
+    peer: SocketAddr,
+    ws_receiver: SplitStream<WebSocketStream<TcpStream>>,
+    client: AsyncClient,
+) {
     if let Err(e) = handle_reading_ws(peer, ws_receiver, client).await {
         match e {
             Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
@@ -30,7 +42,11 @@ async fn accept_connection_for_reading_ws(peer: SocketAddr, ws_receiver: SplitSt
 
 ///
 /// Handle incoming WS messages
-async fn handle_reading_ws(peer: SocketAddr, mut ws_receiver:  SplitStream<WebSocketStream<TcpStream>>, client: AsyncClient) -> Result<()> {
+async fn handle_reading_ws(
+    peer: SocketAddr,
+    mut ws_receiver: SplitStream<WebSocketStream<TcpStream>>,
+    client: AsyncClient,
+) -> Result<()> {
     println!("Send a message");
     loop {
         println!("Loop is spinning");
@@ -63,38 +79,68 @@ struct BridgeMessage {
     raw_message: String, // Json string of the actual message
 }
 
-
-async fn mqtt_open(user : &str, pass: &str) -> (AsyncClient, EventLoop) {
-
+async fn mqtt_open(user: &str, pass: &str) -> (AsyncClient, EventLoop) {
     info!("Open Mqtt connection");
 
     // Mosquitto
     let uuid = Uuid::new_v4();
-    let mut mqttoptions = MqttOptions::new(format!("bridge-client-{}", uuid), "192.168.0.149", 1883);
+    let mut mqttoptions =
+        MqttOptions::new(format!("bridge-client-{}", uuid), "192.168.0.149", 1883);
     mqttoptions.set_keep_alive(Duration::from_secs(30_000));
     mqttoptions.set_clean_start(true);
     mqttoptions.set_credentials(user, pass);
 
-    let (client, eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, eventloop) = AsyncClient::new(mqttoptions, 100);
 
     info!("Subscribe to channels");
-    client.subscribe("*", QoS::AtMostOnce).await.unwrap();
-    client.subscribe("zigbee2mqtt/ts_salon_1", QoS::AtMostOnce).await.unwrap();
-    client.subscribe("zigbee2mqtt/bureau", QoS::AtMostOnce).await.unwrap();
-    client.subscribe("zigbee2mqtt/ts_chambre_1", QoS::AtMostOnce).await.unwrap();
-    client.subscribe("zigbee2mqtt/ts_couloir", QoS::AtMostOnce).await.unwrap();
+    client.subscribe("*", QoS::AtLeastOnce).await.unwrap();
+    client
+        .subscribe("zigbee2mqtt/ts_salon_1", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    client
+        .subscribe("zigbee2mqtt/bureau", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    client
+        .subscribe("zigbee2mqtt/ts_chambre_1", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    client
+        .subscribe("zigbee2mqtt/ts_couloir", QoS::AtLeastOnce)
+        .await
+        .unwrap();
 
-    client.subscribe("regulator/regulate_radiator", QoS::AtMostOnce).await.unwrap();
+    client
+        .subscribe("regulator/regulate_radiator", QoS::AtLeastOnce)
+        .await
+        .unwrap();
 
-    client.subscribe("external/rad_salon", QoS::AtMostOnce).await.unwrap();
-    client.subscribe("external/rad_bureau", QoS::AtMostOnce).await.unwrap();
-    client.subscribe("external/rad_chambre", QoS::AtMostOnce).await.unwrap();
-    client.subscribe("external/rad_couloir", QoS::AtMostOnce).await.unwrap();
+    client
+        .subscribe("external/rad_salon", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    client
+        .subscribe("external/rad_bureau", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    client
+        .subscribe("external/rad_chambre", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    client
+        .subscribe("external/rad_couloir", QoS::AtLeastOnce)
+        .await
+        .unwrap();
 
     (client, eventloop)
 }
 
-async fn handle_writing_ws(peer: SocketAddr, mut ws_sender: SplitSink<WebSocketStream<TcpStream>, Message>, mut eventloop: EventLoop) -> Result<()> {
+async fn handle_writing_ws(
+    peer: SocketAddr,
+    mut ws_sender: SplitSink<WebSocketStream<TcpStream>, Message>,
+    mut eventloop: EventLoop,
+) -> Result<()> {
     info!("WebSocket connection: {}", &peer);
 
     while let Ok(notification) = eventloop.poll().await {
@@ -103,22 +149,23 @@ async fn handle_writing_ws(peer: SocketAddr, mut ws_sender: SplitSink<WebSocketS
             Event::Incoming(Incoming::Publish(publish)) => {
                 let topic = std::str::from_utf8(publish.topic.as_ref()).unwrap(); // TODO
                 let msg = std::str::from_utf8(&publish.payload).unwrap();
-                info!("🧶 Client [{}] is reading mqtt message on topic: [{}], message: <{}>", &peer, topic, msg);
+                info!(
+                    "🧶 Client [{}] is reading mqtt message on topic: [{}], message: <{}>",
+                    &peer, topic, msg
+                );
 
                 // Send the mqtt message to the ws client
                 println!("Send a WS message to the web client: [{}]", &peer);
                 let m = serde_json::to_string(&BridgeMessage {
                     topic: topic.to_string(),
                     raw_message: msg.to_string(),
-                }).unwrap();
+                })
+                .unwrap();
                 let m = Message::Text(m);
                 ws_sender.send(m).await?;
-
             }
-            Event::Incoming(Incoming::ConnAck(_connack)) => {
-            }
-            Event::Incoming(Incoming::PubAck(_pub_ack)) => {
-            }
+            Event::Incoming(Incoming::ConnAck(_connack)) => {}
+            Event::Incoming(Incoming::PubAck(_pub_ack)) => {}
             _ => {}
         }
     }
@@ -164,26 +211,33 @@ fn read_host() -> (String, String, String) {
     let ip = if let Some(ip) = host_address {
         println!("Adresse IP de l'hôte : {}", ip);
         ip
-    } else { panic!("Missing host address")};
+    } else {
+        panic!("Missing host address")
+    };
     let user = if let Some(user) = mqtt_user {
         println!("Nom d'utilisateur MQTT : {}", user);
         user
-    } else { panic!("Missing mqtt user")};
+    } else {
+        panic!("Missing mqtt user")
+    };
     let pass = if let Some(pass) = mqtt_pass {
         println!("Mot de passe MQTT : ...");
         pass
-    } else { panic!("Missing mqtt password")};
+    } else {
+        panic!("Missing mqtt password")
+    };
 
     (ip, user, pass)
 }
 
-
 #[tokio::main]
 async fn main() {
-
     // --host 192.168.0.99
 
-    env::set_var("RUST_LOG", env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()));
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init();
 
     info!("Starting Mqtt Bridge 0.7.0");
@@ -191,12 +245,14 @@ async fn main() {
     let (ip, mqtt_user, mqtt_pass) = read_host();
 
     // ** Web Socket **
-    let addr = format!("{}:9002", ip);// "192.168.0.99:9002";
+    let addr = format!("{}:9002", ip); // "192.168.0.99:9002";
     let listener = TcpListener::bind(&addr).await.expect("Can't listen");
     info!("Listening on: {}", addr);
 
     while let Ok((stream, _)) = listener.accept().await {
-        let peer = stream.peer_addr().expect("connected streams should have a peer address");
+        let peer = stream
+            .peer_addr()
+            .expect("connected streams should have a peer address");
         info!("Peer address: {}", peer);
         let ws_stream = accept_async(stream).await.expect("Failed to accept");
         let (ws_sender, ws_receiver) = ws_stream.split();

--- a/mqtt5-r/src/main.rs
+++ b/mqtt5-r/src/main.rs
@@ -5,29 +5,29 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use log::info;
-use rumqttc::v5::{AsyncClient, MqttOptions};
 use rumqttc::v5::mqttbytes::QoS;
+use rumqttc::v5::{AsyncClient, MqttOptions};
 
 use crate::device_repo::{build_device_repo, device_to_listen};
+use crate::loops::{build_init_list, build_loops};
+use crate::message_enum::MessageEnum;
 use ava_toolkit::generic_device::GenericDevice;
 use ava_toolkit::hard_loop::HardLoop;
 use ava_toolkit::init_loop::process_initialization_message;
 use ava_toolkit::processing::process_incoming_message;
-use crate::loops::{build_init_list, build_loops};
-use crate::message_enum::MessageEnum;
 
-mod loops;
 mod device_repo;
+mod loops;
 mod message_enum;
 
 const CLIENT_ID: &str = "ava-0.5.0";
 
 #[derive(Debug, Clone)]
 pub struct Params {
-    pub server_addr : String,
-    pub client_id : String,
+    pub server_addr: String,
+    pub client_id: String,
     pub channel_filters: Vec<(String, QoS)>,
-    pub keep_alive :  u16,
+    pub keep_alive: u16,
 }
 
 /// Build the list of channel to listen
@@ -42,18 +42,19 @@ fn parse_params(device_repo: &HashMap<String, Arc<RefCell<GenericDevice<MessageE
     }
 
     Params {
-        server_addr : "raspberrypi.local".to_string(),
+        server_addr: "raspberrypi.local".to_string(),
         client_id,
         channel_filters,
-        keep_alive : 30_000,
+        keep_alive: 30_000,
     }
 }
 
-
 #[tokio::main]
 async fn main() {
-
-    env::set_var("RUST_LOG", env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()));
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init();
 
     info!("Starting AVA 0.5.0");
@@ -62,26 +63,27 @@ async fn main() {
     let args: Vec<String> = vec![];
     let device_repo = build_device_repo();
     let params = parse_params(&device_repo);
-    
+
     let mut mqttoptions = MqttOptions::new(&params.client_id, &params.server_addr, 1883);
     mqttoptions.set_keep_alive(Duration::from_secs(params.keep_alive as u64));
     mqttoptions.set_clean_start(true);
     mqttoptions.set_credentials("ava", "avatece3.X");
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 100);
 
     for p in &params.channel_filters {
         info!("Subscribe to [{}]", p.0);
-        client.subscribe(p.0.clone(), QoS::AtMostOnce).await.unwrap();
+        client
+            .subscribe(p.0.clone(), QoS::AtLeastOnce)
+            .await
+            .unwrap();
     }
 
     let mut init_list = build_init_list(&device_repo);
     let all_loops = build_loops(&device_repo);
-    
-    let loop_finder = |topic: &str| {
-        HardLoop::find_loops(topic, &all_loops)
-    };
-    
+
+    let loop_finder = |topic: &str| HardLoop::find_loops(topic, &all_loops);
+
     match process_initialization_message(&mut client, &mut eventloop, &mut init_list).await {
         Ok(_) => {
             info!("Process incoming messages");
@@ -93,6 +95,3 @@ async fn main() {
     }
     println!("Done!");
 }
-
-
-

--- a/radiator-ctrl/src/main.rs
+++ b/radiator-ctrl/src/main.rs
@@ -1,22 +1,24 @@
-use std::env;
-use std::time::Duration;
 use crate::message_enum::MessageEnum;
 use ava_toolkit::domotic_factory::DomoticFactory;
 use ava_toolkit::hard_loop::HardLoop;
 use ava_toolkit::init_loop::process_initialization_message;
 use ava_toolkit::processing::process_incoming_message;
+use common_config::conf_reader::{read_config, read_env};
+use common_config::properties::{get_prop_value, set_prop_values};
 use log::{error, info};
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, MqttOptions};
-use common_config::conf_reader::{read_config, read_env};
-use common_config::properties::{get_prop_value, set_prop_values};
+use std::env;
+use std::time::Duration;
 
 mod message_enum;
 
 #[tokio::main]
 async fn main() {
-
-    env::set_var("RUST_LOG", env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()));
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init();
 
     let args: Vec<String> = env::args().collect();
@@ -29,9 +31,16 @@ async fn main() {
     let o_config_file = read_env(&VAR_NAME);
 
     // Read the application config's file
-    println!("😎 Config file using PROJECT_CODE={} VAR_NAME={}", PROJECT_CODE, VAR_NAME);
+    println!(
+        "😎 Config file using PROJECT_CODE={} VAR_NAME={}",
+        PROJECT_CODE, VAR_NAME
+    );
 
-    let props = read_config(PROJECT_CODE, &o_config_file, &Some("AVA_CLUSTER_PROFILE".to_string()));
+    let props = read_config(
+        PROJECT_CODE,
+        &o_config_file,
+        &Some("AVA_CLUSTER_PROFILE".to_string()),
+    );
     set_prop_values(props);
 
     let factory_message_dir = read_props_or_die("factory.dir");
@@ -41,13 +50,14 @@ async fn main() {
     let mqtt_password = read_props_or_die("mqtt.password");
     let mqtt_host = read_props_or_die("mqtt.host");
 
-    let mut domo_factory: DomoticFactory<MessageEnum> = DomoticFactory::new(module_file, factory_message_dir);
+    let mut domo_factory: DomoticFactory<MessageEnum> =
+        DomoticFactory::new(module_file, factory_message_dir);
     domo_factory.build_devices();
 
     let all_loops = domo_factory.build_loops();
     let init_list = domo_factory.devices_to_init();
     let device_to_listen = domo_factory.devices_to_listen();
-    
+
     let channels = DomoticFactory::extract_channel_from_devices(&device_to_listen, &mqtt_host);
 
     let mut mqttoptions = MqttOptions::new(&channels.client_id, &channels.server_addr, mqtt_port);
@@ -55,16 +65,17 @@ async fn main() {
     mqttoptions.set_clean_start(true);
     mqttoptions.set_credentials(mqtt_user, mqtt_password);
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 100);
 
     for p in &channels.channel_filters {
         info!("Subscribe to [{}]", p.0);
-        client.subscribe(p.0.clone(), QoS::AtMostOnce).await.unwrap();
+        client
+            .subscribe(p.0.clone(), QoS::AtLeastOnce)
+            .await
+            .unwrap();
     }
 
-    let loop_finder = |topic: &str| {
-        HardLoop::find_loops(topic, &all_loops)
-    };
+    let loop_finder = |topic: &str| HardLoop::find_loops(topic, &all_loops);
 
     match process_initialization_message(&mut client, &mut eventloop, &init_list).await {
         Ok(_) => {
@@ -88,5 +99,3 @@ fn read_props_or_die(property_name: &str) -> String {
     };
     value
 }
-
-

--- a/regulator-heart-beat/src/main.rs
+++ b/regulator-heart-beat/src/main.rs
@@ -1,4 +1,3 @@
-
 use std::env;
 use std::process::exit;
 use std::time::Duration;
@@ -15,16 +14,17 @@ use log::*;
 use rumqttc::v5::{AsyncClient, Event, Incoming, MqttOptions};
 use tokio::time::interval;
 
-mod message_enum;
 mod dao;
+mod message_enum;
 
-
-pub (crate) const REGULATE_RADIATOR: &str = "regulate_radiator";
+pub(crate) const REGULATE_RADIATOR: &str = "regulate_radiator";
 
 #[tokio::main]
 async fn main() {
-
-    env::set_var("RUST_LOG", env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()));
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init();
 
     info!("Starting AVA regulator-heart-beat 0.5.0");
@@ -35,12 +35,23 @@ async fn main() {
     let o_config_file = read_env(&VAR_NAME);
 
     // Read the application config's file
-    println!("😎 Config file using PROJECT_CODE={} VAR_NAME={}", PROJECT_CODE, VAR_NAME);
+    println!(
+        "😎 Config file using PROJECT_CODE={} VAR_NAME={}",
+        PROJECT_CODE, VAR_NAME
+    );
 
-    let props = read_config(PROJECT_CODE, &o_config_file, &Some("AVA_CLUSTER_PROFILE".to_string()));
+    let props = read_config(
+        PROJECT_CODE,
+        &o_config_file,
+        &Some("AVA_CLUSTER_PROFILE".to_string()),
+    );
     set_prop_values(props);
 
-    let props = common_config::conf_reader::read_config(PROJECT_CODE, &o_config_file, &Some("AVA_CLUSTER_PROFILE".to_string()));
+    let props = common_config::conf_reader::read_config(
+        PROJECT_CODE,
+        &o_config_file,
+        &Some("AVA_CLUSTER_PROFILE".to_string()),
+    );
     set_prop_values(props);
 
     let factory_message_dir = read_props_or_die("factory.dir");
@@ -50,9 +61,10 @@ async fn main() {
     let mqtt_password = read_props_or_die("mqtt.password");
     let mqtt_host = read_props_or_die("mqtt.host");
 
-    let mut domo_factory: DomoticFactory<MessageEnum> = DomoticFactory::new(module_file, factory_message_dir);
+    let mut domo_factory: DomoticFactory<MessageEnum> =
+        DomoticFactory::new(module_file, factory_message_dir);
     domo_factory.build_devices();
-    
+
     let device_to_listen = domo_factory.devices_to_listen();
     let device_repo = domo_factory.repo();
 
@@ -65,7 +77,7 @@ async fn main() {
     mqttoptions.set_clean_start(true);
     mqttoptions.set_credentials(mqtt_user, mqtt_password);
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 100);
 
     // Init DB pool
     let (connect_string, db_pool_size) = match get_prop_pg_connect_string()
@@ -82,15 +94,22 @@ async fn main() {
 
     let _r = init_db_pool2(&connect_string, db_pool_size).await;
 
-    let device = device_repo.get(REGULATE_RADIATOR).unwrap().as_ref().borrow();
+    let device = device_repo
+        .get(REGULATE_RADIATOR)
+        .unwrap()
+        .as_ref()
+        .borrow();
 
     //  5 minutes
-    let mut interval = interval(Duration::from_secs(5*60));
+    let mut interval = interval(Duration::from_secs(5 * 60));
     loop {
         interval.tick().await;
 
         if let Ok(reg_plan) = get_current_regulation_map().await {
-            info!("L'heure actuelle est entre {} et {}.", reg_plan.0, reg_plan.1);
+            info!(
+                "L'heure actuelle est entre {} et {}.",
+                reg_plan.0, reg_plan.1
+            );
             let msg = MessageEnum::RegulationMap(reg_plan.2);
 
             info!("prepare to send :  [{:?}]", &msg);

--- a/regulator/src/main.rs
+++ b/regulator/src/main.rs
@@ -1,5 +1,3 @@
-
-
 use std::env;
 use std::time::Duration;
 
@@ -15,15 +13,17 @@ use log::{error, info};
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, MqttOptions};
 
-mod message_enum;
 mod external_computing;
+mod message_enum;
 
 #[tokio::main]
 async fn main() {
-
     // run --package regulator --bin regulator -- --cluster-profile ava_home_01
 
-    env::set_var("RUST_LOG", env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()));
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init();
 
     info!("Starting AVA regulator 0.5.0");
@@ -34,9 +34,16 @@ async fn main() {
     let o_config_file = read_env(&VAR_NAME);
 
     // Read the application config's file
-    println!("😎 Config file using PROJECT_CODE={} VAR_NAME={}", PROJECT_CODE, VAR_NAME);
+    println!(
+        "😎 Config file using PROJECT_CODE={} VAR_NAME={}",
+        PROJECT_CODE, VAR_NAME
+    );
 
-    let props = read_config(PROJECT_CODE, &o_config_file, &Some("AVA_CLUSTER_PROFILE".to_string()));
+    let props = read_config(
+        PROJECT_CODE,
+        &o_config_file,
+        &Some("AVA_CLUSTER_PROFILE".to_string()),
+    );
     set_prop_values(props);
 
     let factory_message_dir = read_props_or_die("factory.dir");
@@ -46,7 +53,8 @@ async fn main() {
     let mqtt_password = read_props_or_die("mqtt.password");
     let mqtt_host = read_props_or_die("mqtt.host");
 
-    let mut domo_factory: DomoticFactory<MessageEnum> = DomoticFactory::new(module_file, factory_message_dir);
+    let mut domo_factory: DomoticFactory<MessageEnum> =
+        DomoticFactory::new(module_file, factory_message_dir);
     domo_factory.build_devices();
 
     let all_loops = domo_factory.build_loops();
@@ -61,17 +69,18 @@ async fn main() {
     mqttoptions.set_clean_start(true);
     mqttoptions.set_credentials(mqtt_user, mqtt_password);
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 100);
 
     for p in &channels.channel_filters {
         info!("Subscribe to [{}]", p.0);
-        client.subscribe(p.0.clone(), QoS::AtMostOnce).await.unwrap();
+        client
+            .subscribe(p.0.clone(), QoS::AtLeastOnce)
+            .await
+            .unwrap();
     }
 
-    let loop_finder = |topic: &str| {
-        HardLoop::find_loops(topic, &all_loops)
-    };
-    
+    let loop_finder = |topic: &str| HardLoop::find_loops(topic, &all_loops);
+
     match process_initialization_message(&mut client, &mut eventloop, &init_list).await {
         Ok(_) => {
             info!("Process incoming messages");
@@ -94,5 +103,3 @@ fn read_props_or_die(property_name: &str) -> String {
     };
     value
 }
-
-


### PR DESCRIPTION
## Summary
- raise MQTT client request queue sizes to 100 across remaining services
- subscribe with at-least-once QoS to improve reliability for control loops and bridge

## Testing
- cargo fmt

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256526a31c832d9d33be24fb9aa233)