### PR TITLE
Use fixed MQTT client id from PROJECT_CODE and improve MQTT reliability

### DIFF
--- a/ava-toolkit/src/domotic_factory.rs
+++ b/ava-toolkit/src/domotic_factory.rs
@@ -67,8 +67,8 @@ pub struct Channels {
     pub keep_alive :  u16,
 }
 
-fn generate_client_id() -> String {
-    format!("{}", Uuid::new_v4())
+fn generate_client_id(prefix: &str) -> String {
+    format!("{}-{}", prefix, Uuid::new_v4())
 }
 
 
@@ -94,14 +94,18 @@ impl<T: Locality + Clone + DeserializeOwned> DomoticFactory<T> {
 
     /// Static
     /// Extract channel name from devices
-    pub fn extract_channel_from_devices(devices : &Vec<Arc<RefCell<GenericDevice<T>>>>, mqtt_host: &str) -> Channels {
-        let client_id = generate_client_id(); // CLIENT_ID.to_string();
+    pub fn extract_channel_from_devices(
+        devices: &Vec<Arc<RefCell<GenericDevice<T>>>>,
+        mqtt_host: &str,
+        client_id: &str,
+    ) -> Channels {
+        let client_id = client_id.to_string();
 
         let mut channel_filters: Vec<(String, QoS)> = vec![];
         for dev in devices {
             let dd = dev.as_ref().borrow();
             let topic = dd.get_topic();
-            channel_filters.push((topic, QoS::AtMostOnce));
+            channel_filters.push((topic, QoS::AtLeastOnce));
         }
 
         Channels {

--- a/ava-toolkit/src/init_loop.rs
+++ b/ava-toolkit/src/init_loop.rs
@@ -5,6 +5,7 @@ use log::info;
 use rumqttc::v5::{AsyncClient, Event, EventLoop, Incoming};
 use rumqttc::v5::mqttbytes::QoS;
 use serde::de::DeserializeOwned;
+use tokio::time::{timeout, Duration, Instant};
 use crate::generic_device::{GenericDevice, Locality};
 
 /// Send an information request for all devices that need initialization.
@@ -39,11 +40,23 @@ where
                 .map_err(|e| format!("Publish failed: {}", e))?;
         }
 
+        let deadline = Instant::now() + Duration::from_secs(60);
+
         // Wait for all devices to acknowledge initialization
-        while let Ok(notification) = eventloop.poll().await {
+        while Instant::now() < deadline {
             let mut end_loop = true;
 
-            handle_event(notification, device_to_init).await;
+            match timeout(Duration::from_secs(5), eventloop.poll()).await {
+                Ok(Ok(notification)) => {
+                    handle_event(notification, device_to_init).await;
+                }
+                Ok(Err(e)) => {
+                    info!("Init loop event error: {}", e);
+                }
+                Err(_) => {
+                    info!("Init loop timeout while waiting for devices");
+                }
+            }
 
             for dev in device_to_init {
                 let borr = dev.as_ref().borrow();
@@ -61,6 +74,10 @@ where
             if end_loop {
                 break;
             }
+        }
+
+        if Instant::now() >= deadline {
+            info!("Initialization stage timeout; continuing without full init");
         }
     } else {
         info!("No devices to initialize");

--- a/ava-toolkit/src/processing.rs
+++ b/ava-toolkit/src/processing.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use log::{info, error, debug};
 use rumqttc::v5::{AsyncClient, Event, EventLoop, Incoming};
 use serde::de::DeserializeOwned;
+use tokio::time::{sleep, Duration};
 use crate::generic_device::{GenericDevice, Locality};
 use crate::hard_loop::HardLoop;
 
@@ -20,8 +21,9 @@ where
 {
     info!("Process incoming message");
 
-    while let Ok(notification) = eventloop.poll().await {
-        match notification {
+    loop {
+        match eventloop.poll().await {
+            Ok(notification) => match notification {
             Event::Incoming(Incoming::Publish(publish)) => {
                 let msg = std::str::from_utf8(&publish.payload).unwrap();
                 let topic = std::str::from_utf8(publish.topic.as_ref()).unwrap();
@@ -72,7 +74,11 @@ where
             _ => {
                 debug!("Other cases!");
             }
+            },
+            Err(e) => {
+                error!("MQTT event loop error: {}", e);
+                sleep(Duration::from_millis(500)).await;
+            }
         }
     }
 }
-

--- a/luminator/src/main.rs
+++ b/luminator/src/main.rs
@@ -52,18 +52,22 @@ async fn main() {
     let device_to_listen = domo_factory.devices_to_listen();
 
     let args: Vec<String> = vec![];
-    let channels = DomoticFactory::extract_channel_from_devices(&device_to_listen, mqtt_host.as_str());
+    let channels = DomoticFactory::extract_channel_from_devices(
+        &device_to_listen,
+        mqtt_host.as_str(),
+        PROJECT_CODE,
+    );
     
     let mut mqttoptions = MqttOptions::new(&channels.client_id, &channels.server_addr, mqtt_port);
     mqttoptions.set_keep_alive(Duration::from_secs(channels.keep_alive as u64));
-    mqttoptions.set_clean_start(true);
+    mqttoptions.set_clean_start(false);
     mqttoptions.set_credentials(mqtt_user, mqtt_password);
 
     let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
 
     for p in &channels.channel_filters {
         info!("Subscribe to [{}]", p.0);
-        client.subscribe(p.0.clone(), QoS::AtMostOnce).await.unwrap();
+        client.subscribe(p.0.clone(), QoS::AtLeastOnce).await.unwrap();
     }
     
     let loop_finder = |topic: &str| {
@@ -92,4 +96,3 @@ fn read_props_or_die(property_name: &str) -> String {
     };
     value
 }
-


### PR DESCRIPTION
### Motivation

- Use a stable MQTT client id derived from the project code to make client identity predictable and support persistent sessions.
- Improve message delivery reliability by using `QoS::AtLeastOnce` for subscriptions.
- Prevent the initialization phase from blocking indefinitely when devices do not reply by introducing timeouts/deadlines.
- Increase resilience of the main MQTT event loop against transient `poll()` errors to avoid crashes.

### Description

- Change `generate_client_id` to `fn generate_client_id(prefix: &str) -> String` and modify `DomoticFactory::extract_channel_from_devices` to accept a `client_id: &str` and use it for the returned `Channels::client_id`.
- In `luminator::main` pass `PROJECT_CODE` into `extract_channel_from_devices`, set `mqttoptions.set_clean_start(false)`, and subscribe using `QoS::AtLeastOnce`.
- In `ava-toolkit::init_loop` add an overall `deadline`, wrap `eventloop.poll()` calls with `timeout(Duration::from_secs(5), ...)`, and log on poll errors and timeouts while continuing the init flow.
- In `ava-toolkit::processing.rs` replace the `while let Ok(notification) = eventloop.poll().await` loop with a `loop` that handles `Err(e)` results from `eventloop.poll()` and `sleep`s briefly on errors.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b86ed8060832d9df7bc12de7dd021)