### PR TITLE
Add new radiator-api subproject with /update-radiator endpoint

### DIFF
--- a/.run/Run radiator-api.run.xml
+++ b/.run/Run radiator-api.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run radiator-api" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package radiator-api --bin radiator-api -- --cluster-profile ava_home_01" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Run radiator-ctrl.run.xml
+++ b/.run/Run radiator-ctrl.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run radiator-ctrl" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package radiator-ctrl --bin radiator-ctrl -- --cluster-profile ava_home_01" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -119,12 +113,6 @@ name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
-
-[[package]]
-name = "arc-swap"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arc-swap"
@@ -239,9 +227,9 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "miniz_oxide 0.7.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -323,12 +311,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -349,15 +331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,7 +347,7 @@ dependencies = [
  "java-properties",
  "lazy_static",
  "log",
- "log4rs 1.3.0",
+ "log4rs",
  "once_cell",
  "serde",
  "serde_derive",
@@ -387,7 +360,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "log",
- "log4rs 1.3.0",
+ "log4rs",
 ]
 
 [[package]]
@@ -400,7 +373,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "log4rs 1.3.0",
+ "log4rs",
  "mut_static",
  "postgres",
  "postgres-types",
@@ -466,15 +439,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,7 +501,7 @@ dependencies = [
  "java-properties",
  "lazy_static",
  "log",
- "log4rs 0.11.0",
+ "log4rs",
  "mut_static",
  "obfstr",
  "okapi",
@@ -720,7 +684,7 @@ version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -742,7 +706,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime 2.1.0",
+ "humantime",
  "log",
 ]
 
@@ -774,7 +738,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "home",
  "windows-sys 0.48.0",
 ]
@@ -823,16 +787,6 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
-
-[[package]]
-name = "flate2"
-version = "1.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
-dependencies = [
- "crc32fast",
- "miniz_oxide 0.8.0",
-]
 
 [[package]]
 name = "flume"
@@ -930,8 +884,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
- "lock_api 0.4.11",
- "parking_lot 0.12.1",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1003,7 +957,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1014,7 +968,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -1037,7 +991,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1060,12 +1014,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1080,7 +1028,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1228,15 +1176,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -1348,22 +1287,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1447,25 +1376,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "lock_api"
@@ -1494,53 +1408,28 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47ba5437ccdf01e4addd4d2347ef561911d57f908f4db1e1b192d5c25a92715"
-dependencies = [
- "arc-swap 0.4.8",
- "chrono",
- "flate2",
- "fnv",
- "humantime 1.3.0",
- "libc",
- "log",
- "log-mdc",
- "parking_lot 0.10.2",
- "serde",
- "serde-value 0.6.0",
- "serde_derive",
- "serde_json",
- "serde_yaml 0.8.26",
- "thread-id 3.3.0",
- "typemap",
- "winapi",
-]
-
-[[package]]
-name = "log4rs"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
 dependencies = [
  "anyhow",
- "arc-swap 1.6.0",
+ "arc-swap",
  "chrono",
  "derivative",
  "fnv",
- "humantime 2.1.0",
+ "humantime",
  "libc",
  "log",
  "log-mdc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rand 0.8.5",
  "serde",
- "serde-value 0.7.0",
+ "serde-value",
  "serde_json",
- "serde_yaml 0.9.31",
+ "serde_yaml",
  "thiserror",
- "thread-id 4.2.1",
+ "thread-id",
  "typemap-ors",
  "winapi",
 ]
@@ -1572,7 +1461,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "digest",
 ]
 
@@ -1611,15 +1500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
-dependencies = [
- "adler2",
 ]
 
 [[package]]
@@ -1829,7 +1709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.4.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1874,15 +1754,6 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
@@ -1898,36 +1769,12 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.11",
- "parking_lot_core 0.9.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93f386bb233083c799e6e642a9d73db98c24a5deeb95ffc85bf281255dffc98"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1936,9 +1783,9 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -2132,12 +1979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,7 +1994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -2322,12 +2163,6 @@ checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
 ]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -2666,7 +2501,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2732,21 +2567,11 @@ dependencies = [
 
 [[package]]
 name = "serde-value"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
-dependencies = [
- "ordered-float 1.1.1",
- "serde",
-]
-
-[[package]]
-name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.1",
+ "ordered-float",
  "serde",
 ]
 
@@ -2819,23 +2644,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2848,7 +2661,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2859,7 +2672,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2935,7 +2748,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api 0.4.11",
+ "lock_api",
 ]
 
 [[package]]
@@ -2990,10 +2803,10 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown",
  "hashlink",
  "hex",
- "indexmap 2.2.3",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -3237,7 +3050,7 @@ version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
@@ -3262,17 +3075,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
-]
-
-[[package]]
-name = "thread-id"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-dependencies = [
- "libc",
- "redox_syscall 0.1.57",
- "winapi",
 ]
 
 [[package]]
@@ -3341,7 +3143,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3383,7 +3185,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "percent-encoding",
  "phf",
  "pin-project-lite",
@@ -3530,12 +3332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,15 +3354,6 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
-]
-
-[[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
 ]
 
 [[package]]
@@ -3625,15 +3412,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
 
 [[package]]
 name = "unsafe-any-ors"
@@ -3739,7 +3517,7 @@ version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -3764,7 +3542,7 @@ version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4013,7 +3791,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 
@@ -4022,15 +3800,6 @@ name = "xml-rs"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "radiator-api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ava-toolkit",
+ "axum",
+ "chrono",
+ "common-config",
+ "env_logger",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "radiator-ctrl"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "mqtt-bridge",
     "radiator-ctrl",
     "dashboard", "ava-toolkit",
+    "radiator-api",
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "commons-error",
     "commons-pg",
@@ -32,7 +33,7 @@ serde_json = "^1.0"
 serde_derive = "^1.0"
 uuid = { version = "^1.6", features = ["v4"] }
 async-trait = "^0.1"
-tokio-postgres = "0.7.10"
+tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4"] }
 tokio = { version = "^1", features = ["full"] }
 axum = { version = "^0.7", features = ["multipart"] }
 sqlx = { version = "^0.8", features = ["postgres", "runtime-tokio-rustls", "chrono"]}
@@ -47,4 +48,3 @@ incremental = true
 
 [profile.dev]
 incremental = true
-

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -14,7 +14,7 @@ serde_derive = "1.0"
 base64 = "0.12.0"
 rs-uuid = "0.3.1"
 log = "0.4"
-log4rs = "0.11.0"
+log4rs = { workspace = true }
 okapi = { version = "0.4", features = ["derive_json_schema"] }
 java-properties = "1.2.0"
 obfstr = "0.2"
@@ -46,7 +46,6 @@ chrono = { workspace = true }
 commons-error = {path= "../commons-error"}
 commons-pg = {path= "../commons-pg" }
 ava-toolkit = {path="../ava-toolkit"}
-
 
 
 

--- a/event-storage/src/message_enum.rs
+++ b/event-storage/src/message_enum.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use log::info;
 use serde_derive::{Deserialize, Serialize};
-use tokio_postgres::{NoTls, types::ToSql};
 
 use ava_toolkit::device_message::{RegulatorRadiatorMsg, TempSensorMsg};
 use ava_toolkit::generic_device::Locality;
@@ -113,54 +112,11 @@ impl Locality for MessageEnum {
 }
 
 /// Insère les données de l'état du périphérique dans la base de données
-pub (crate) async fn db_put_device_state(topic: &str, json_msg: &str) {
-    let db_url = "postgresql://denis:dentece3.X@192.168.0.149/avahome"; // TODO ...
-
-    // Établissez une connexion à la base de données
-    let (client, connection) = tokio_postgres::connect(db_url, NoTls).await.unwrap();
-
-    // Spawn une tâche pour gérer la processus de connexion en arrière-plan
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            eprintln!("Connection error: {}", e);
-        }
-    });
-
-    let query =  r#"INSERT INTO public.device_state_history
-                                (device_name, state, ts_create)
-                                VALUES($1, $2, timezone('UTC', current_timestamp))"#;
-
-    let values: &[&(dyn ToSql + Sync)] = &[&topic, &json_msg];
-    let _ = client.execute(query, values).await.unwrap();
-
-    println!("Données insérées avec succès!");
+pub (crate) async fn db_put_device_state(_topic: &str, _json_msg: &str) {
+    panic!("Please, grab the db information from the config file !!");
 }
 
 /// Insère les données de température dans la base de données
-pub (crate) async fn insert_temp(topic: &str, temp: &TempSensorMsg) {
-    // Remplacez ces valeurs par les informations de votre base de données
-    let db_url = "postgresql://denis:dentece3.X@192.168.0.149/avahome";
-
-    // Établissez une connexion à la base de données
-    let (client, connection) = tokio_postgres::connect(db_url, NoTls).await.unwrap();
-
-    // Spawn une tâche pour gérer la processus de connexion en arrière-plan
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            eprintln!("Connection error: {}", e);
-        }
-    });
-
-    // Données à insérer
-    let device_name = topic;
-    let temperature = temp.temperature as f64;
-    // let ts_create = chrono::Utc::now();
-
-    // Exécutez une requête d'insertion
-    let query = "INSERT INTO temperature_sensor_history (device_name, temperature, ts_create) VALUES ($1, $2, timezone('UTC', current_timestamp))";
-    let values: &[&(dyn ToSql + Sync)] = &[&device_name, &temperature];
-
-    let _ = client.execute(query, values).await.unwrap();
-
-    println!("Données insérées avec succès!");
+pub (crate) async fn insert_temp(_topic: &str, _temp: &TempSensorMsg) {
+    panic!("Please, grab the db information from the config file !!");
 }

--- a/radiator-api/Cargo.toml
+++ b/radiator-api/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "radiator-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+chrono = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_derive = { workspace = true }
+tokio = { workspace = true }
+tokio-postgres = { workspace = true }
+
+ava-toolkit = { path = "../ava-toolkit" }
+common-config = { path = "../common-config" }

--- a/radiator-api/src/api.rs
+++ b/radiator-api/src/api.rs
@@ -16,6 +16,10 @@ const RAD_SALON: &str = "external/rad_salon";
 const RAD_BUREAU: &str = "external/rad_bureau";
 const RAD_COULOIR: &str = "external/rad_couloir";
 const RAD_CHAMBRE: &str = "external/rad_chambre";
+const TS_SALON: &str = "homey/ts_salon_1";
+const TS_BUREAU: &str = "homey/ts_bureau";
+const TS_COULOIR: &str = "homey/ts_couloir";
+const TS_CHAMBRE: &str = "homey/ts_chambre_1";
 
 const CURRENT_REGULATION_MAP_SQL: &str = r"SELECT id, starting_time, ending_time, end_the_next_day, boost, regulation_map::text AS regulation_map_json, ts_created
 FROM public.heating_plan
@@ -110,6 +114,11 @@ pub async fn update_radiator(
             error!("Database connection error: {}", e);
         }
     });
+
+    save_input_temperatures(&client, &payload)
+        .await
+        .map_err(internal_error)?;
+    info!("📝 Stored incoming temperatures into temperature_sensor_history");
 
     // 2) Load target temperatures from the currently active heating plan.
     let regulation_map = get_current_regulation_map(&client)
@@ -245,6 +254,31 @@ pub async fn update_radiator(
 
     info!("🏁 Updated radiators response: {:?}", updated_radiators);
     Ok(Json(UpdateRadiatorResponse { updated_radiators }))
+}
+
+async fn save_input_temperatures(
+    client: &tokio_postgres::Client,
+    payload: &UpdateRadiatorRequest,
+) -> anyhow::Result<()> {
+    let readings = [
+        (TS_BUREAU, payload.bureau),
+        (TS_CHAMBRE, payload.chambre),
+        (TS_COULOIR, payload.couloir),
+        (TS_SALON, payload.salon),
+    ];
+
+    let query = r#"INSERT INTO temperature_sensor_history (device_name, temperature, ts_create)
+VALUES ($1, $2, timezone('UTC', current_timestamp))"#;
+
+    for (device_name, temperature) in readings {
+        client.execute(query, &[&device_name, &temperature]).await?;
+        info!(
+            "\t📝 Stored input temperature for sensor {} = [{}]",
+            device_name, temperature
+        );
+    }
+
+    Ok(())
 }
 
 /// Load the active heating plan according to local time.

--- a/radiator-api/src/api.rs
+++ b/radiator-api/src/api.rs
@@ -5,7 +5,7 @@ use ava_toolkit::device_message::RadiatorMode;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
-use chrono::Local;
+use chrono::{Local, NaiveTime};
 use log::error;
 use reqwest::header;
 use serde_derive::{Deserialize, Serialize};
@@ -215,7 +215,7 @@ pub async fn update_radiator(
 async fn get_current_regulation_map(
     client: &tokio_postgres::Client,
 ) -> anyhow::Result<RegulationMap> {
-    let local_time = Local::now().time().format("%H:%M:%S").to_string();
+    let local_time: NaiveTime = Local::now().time();
 
     let row = client
         .query_opt(CURRENT_REGULATION_MAP_SQL, &[&local_time])

--- a/radiator-api/src/api.rs
+++ b/radiator-api/src/api.rs
@@ -6,7 +6,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use chrono::{Local, NaiveTime};
-use log::error;
+use log::{error, info};
 use reqwest::header;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
@@ -98,6 +98,8 @@ pub async fn update_radiator(
     State(state): State<AppState>,
     Json(payload): Json<UpdateRadiatorRequest>,
 ) -> Result<Json<UpdateRadiatorResponse>, (StatusCode, String)> {
+    info!("🚀 Process radiator update request: {:?}", payload);
+
     // 1) Open a dedicated DB connection for this request.
     let (client, connection) = tokio_postgres::connect(&state.db_url, NoTls)
         .await
@@ -113,11 +115,13 @@ pub async fn update_radiator(
     let regulation_map = get_current_regulation_map(&client)
         .await
         .map_err(internal_error)?;
+    info!("✅ Current regulation map: {:?}", regulation_map);
 
     // 3) Load latest persisted radiator states to avoid unnecessary calls.
     let current_states = get_latest_radiator_states(&client)
         .await
         .map_err(internal_error)?;
+    info!("✅ Latest radiator states: {:?}", current_states);
 
     let room_temperatures = HashMap::from([
         (RAD_BUREAU.to_string(), payload.bureau),
@@ -145,6 +149,8 @@ pub async fn update_radiator(
 
     // 4) For each room: compute action, call Heatzy only when needed, then persist new state.
     for radiator in [RAD_BUREAU, RAD_CHAMBRE, RAD_COULOIR, RAD_SALON] {
+        info!("Prepare the message to send for the device: [{}]", radiator);
+
         let current_mode = current_states
             .get(radiator)
             .ok_or_else(|| {
@@ -157,6 +163,7 @@ pub async fn update_radiator(
 
         // Business rule inherited from regulator: ECO mode is manually forced and must not be overridden.
         if current_mode == RadiatorMode::ECO {
+            info!("\t🧊 Radiator {} is in ECO mode, no override will be applied", radiator);
             continue;
         }
 
@@ -174,7 +181,14 @@ pub async fn update_radiator(
             )
         })?;
 
+        info!(
+            "For device {}, current [{}], target: [{}]",
+            radiator, t_current, t_target
+        );
+
         let action = determine_action(t_current, t_target);
+        info!("The action to perform is: [{:?}]", action);
+
         let next_mode = match action {
             RadiatorAction::On => Some(RadiatorMode::CFT),
             RadiatorAction::Off => Some(RadiatorMode::STOP),
@@ -183,10 +197,18 @@ pub async fn update_radiator(
 
         if let Some(next_mode) = next_mode {
             if next_mode != current_mode {
+                info!(
+                    "\t✅ Radiator {} current mode [{}], next mode [{}]",
+                    radiator,
+                    mode_as_str(current_mode),
+                    mode_as_str(next_mode)
+                );
+
                 let did = did_by_radiator
                     .get(radiator)
                     .ok_or_else(|| internal_error(anyhow!("Missing DID mapping")))?;
 
+                info!("\t📡 Send Heatzy command for radiator {} with DID {}", radiator, did);
                 set_heatzy_mode(
                     &state.heatzy_application_id,
                     &state.heatzy_token,
@@ -199,15 +221,29 @@ pub async fn update_radiator(
                 save_radiator_state(&client, radiator, next_mode)
                     .await
                     .map_err(internal_error)?;
+                info!(
+                    "\t📝 Persisted new state for radiator {} as [{}]",
+                    radiator,
+                    mode_as_str(next_mode)
+                );
 
                 updated_radiators.push(UpdatedRadiator {
                     radiator: radiator.to_string(),
                     status: mode_as_str(next_mode).to_string(),
                 });
+            } else {
+                info!(
+                    "\t✅ Radiator {} already in mode [{}], no update needed",
+                    radiator,
+                    mode_as_str(current_mode)
+                );
             }
+        } else {
+            info!("\t✅ Radiator {} must stay the same", radiator);
         }
     }
 
+    info!("🏁 Updated radiators response: {:?}", updated_radiators);
     Ok(Json(UpdateRadiatorResponse { updated_radiators }))
 }
 

--- a/radiator-api/src/api.rs
+++ b/radiator-api/src/api.rs
@@ -1,0 +1,349 @@
+use std::collections::HashMap;
+
+use anyhow::anyhow;
+use ava_toolkit::device_message::RadiatorMode;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use chrono::Local;
+use log::error;
+use reqwest::header;
+use serde_derive::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio_postgres::NoTls;
+
+const RAD_SALON: &str = "external/rad_salon";
+const RAD_BUREAU: &str = "external/rad_bureau";
+const RAD_COULOIR: &str = "external/rad_couloir";
+const RAD_CHAMBRE: &str = "external/rad_chambre";
+
+const CURRENT_REGULATION_MAP_SQL: &str = r"SELECT id, starting_time, ending_time, end_the_next_day, boost, regulation_map::text AS regulation_map_json, ts_created
+FROM public.heating_plan
+WHERE boost = false
+AND (
+    (
+        end_the_next_day = true
+        AND (
+            (starting_time <= $1)
+            OR ($1 < ending_time)
+        )
+    )
+    OR (
+        end_the_next_day = false
+        AND starting_time <= $1
+        AND $1 < ending_time
+    )
+)
+ORDER BY ts_created DESC
+LIMIT 1";
+
+const LATEST_RADIATOR_STATE_SQL: &str = r"SELECT DISTINCT ON (device_name) device_name, state, ts_create
+FROM public.device_state_history
+WHERE device_name LIKE 'external/rad_%'
+ORDER BY device_name, ts_create DESC";
+
+/// Shared application state injected in Axum handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub db_url: String,
+    pub heatzy_application_id: String,
+    pub heatzy_token: String,
+}
+
+/// Payload expected by POST /update-radiator.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateRadiatorRequest {
+    pub chambre: f64,
+    pub salon: f64,
+    pub couloir: f64,
+    pub bureau: f64,
+}
+
+/// API response with only the radiators that were actually changed.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateRadiatorResponse {
+    pub updated_radiators: Vec<UpdatedRadiator>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdatedRadiator {
+    pub radiator: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RadiatorState {
+    mode: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RegulationMap {
+    tc_bureau: f32,
+    tc_salon_1: f32,
+    tc_salon_2: f32,
+    tc_chambre_1: f32,
+    tc_couloir: f32,
+}
+
+/// Decision returned by temperature control logic.
+#[derive(Debug, Clone, PartialEq)]
+enum RadiatorAction {
+    On,
+    Off,
+    NoAction,
+}
+
+/// Main endpoint: compute required changes, call Heatzy, then persist state changes.
+pub async fn update_radiator(
+    State(state): State<AppState>,
+    Json(payload): Json<UpdateRadiatorRequest>,
+) -> Result<Json<UpdateRadiatorResponse>, (StatusCode, String)> {
+    // 1) Open a dedicated DB connection for this request.
+    let (client, connection) = tokio_postgres::connect(&state.db_url, NoTls)
+        .await
+        .map_err(internal_error)?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            error!("Database connection error: {}", e);
+        }
+    });
+
+    // 2) Load target temperatures from the currently active heating plan.
+    let regulation_map = get_current_regulation_map(&client)
+        .await
+        .map_err(internal_error)?;
+
+    // 3) Load latest persisted radiator states to avoid unnecessary calls.
+    let current_states = get_latest_radiator_states(&client)
+        .await
+        .map_err(internal_error)?;
+
+    let room_temperatures = HashMap::from([
+        (RAD_BUREAU.to_string(), payload.bureau),
+        (RAD_CHAMBRE.to_string(), payload.chambre),
+        (RAD_COULOIR.to_string(), payload.couloir),
+        (RAD_SALON.to_string(), payload.salon),
+    ]);
+
+    let room_targets = HashMap::from([
+        (RAD_BUREAU.to_string(), regulation_map.tc_bureau),
+        (RAD_CHAMBRE.to_string(), regulation_map.tc_chambre_1),
+        (RAD_COULOIR.to_string(), regulation_map.tc_couloir),
+        (RAD_SALON.to_string(), regulation_map.tc_salon_1),
+    ]);
+
+    // Mapping between logical radiator topic and Heatzy DID.
+    let did_by_radiator = HashMap::from([
+        (RAD_SALON.to_string(), "3wHa7Ja50MhfShUxcmOqvT"),
+        (RAD_COULOIR.to_string(), "JUVo7yMFQtdfZhi25Vo4Bu"),
+        (RAD_CHAMBRE.to_string(), "LNENiFG0MeReR9WtxMebYB"),
+        (RAD_BUREAU.to_string(), "mO7E2B49G1BS8R77UmWIjk"),
+    ]);
+
+    let mut updated_radiators = Vec::new();
+
+    // 4) For each room: compute action, call Heatzy only when needed, then persist new state.
+    for radiator in [RAD_BUREAU, RAD_CHAMBRE, RAD_COULOIR, RAD_SALON] {
+        let current_mode = current_states
+            .get(radiator)
+            .ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Missing current state in DB for radiator [{}]", radiator),
+                )
+            })?
+            .clone();
+
+        // Business rule inherited from regulator: ECO mode is manually forced and must not be overridden.
+        if current_mode == RadiatorMode::ECO {
+            continue;
+        }
+
+        let t_current = *room_temperatures.get(radiator).ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Missing temperature for radiator [{}]", radiator),
+            )
+        })?;
+
+        let t_target = *room_targets.get(radiator).ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Missing target temperature for radiator [{}]", radiator),
+            )
+        })?;
+
+        let action = determine_action(t_current, t_target);
+        let next_mode = match action {
+            RadiatorAction::On => Some(RadiatorMode::CFT),
+            RadiatorAction::Off => Some(RadiatorMode::STOP),
+            RadiatorAction::NoAction => None,
+        };
+
+        if let Some(next_mode) = next_mode {
+            if next_mode != current_mode {
+                let did = did_by_radiator
+                    .get(radiator)
+                    .ok_or_else(|| internal_error(anyhow!("Missing DID mapping")))?;
+
+                set_heatzy_mode(
+                    &state.heatzy_application_id,
+                    &state.heatzy_token,
+                    did,
+                    next_mode,
+                )
+                .await
+                .map_err(internal_error)?;
+
+                save_radiator_state(&client, radiator, next_mode)
+                    .await
+                    .map_err(internal_error)?;
+
+                updated_radiators.push(UpdatedRadiator {
+                    radiator: radiator.to_string(),
+                    status: mode_as_str(next_mode).to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(Json(UpdateRadiatorResponse { updated_radiators }))
+}
+
+/// Load the active heating plan according to local time.
+async fn get_current_regulation_map(
+    client: &tokio_postgres::Client,
+) -> anyhow::Result<RegulationMap> {
+    let local_time = Local::now().time().format("%H:%M:%S").to_string();
+
+    let row = client
+        .query_opt(CURRENT_REGULATION_MAP_SQL, &[&local_time])
+        .await?
+        .ok_or_else(|| anyhow!("No current regulation map found"))?;
+
+    let reg_json: String = row.try_get("regulation_map_json")?;
+    let reg: Value = serde_json::from_str(&reg_json)?;
+    let reg_map: RegulationMap = serde_json::from_value(reg)?;
+    Ok(reg_map)
+}
+
+/// Load most recent radiator state for each radiator topic.
+async fn get_latest_radiator_states(
+    client: &tokio_postgres::Client,
+) -> anyhow::Result<HashMap<String, RadiatorMode>> {
+    let rows = client.query(LATEST_RADIATOR_STATE_SQL, &[]).await?;
+
+    let mut states = HashMap::new();
+    for row in rows {
+        let device_name: String = row.try_get("device_name")?;
+        let state_json: String = row.try_get("state")?;
+        let state: RadiatorState = serde_json::from_str(&state_json)?;
+        states.insert(device_name, mode_from_str(&state.mode)?);
+    }
+
+    Ok(states)
+}
+
+/// Persist the new status right after a successful Heatzy update.
+async fn save_radiator_state(
+    client: &tokio_postgres::Client,
+    radiator: &str,
+    mode: RadiatorMode,
+) -> anyhow::Result<()> {
+    let state = serde_json::to_string(&RadiatorState {
+        mode: mode_as_str(mode).to_string(),
+    })?;
+
+    let query = r#"INSERT INTO public.device_state_history (device_name, state, ts_create)
+VALUES($1, $2, timezone('UTC', current_timestamp))"#;
+
+    client.execute(query, &[&radiator, &state]).await?;
+    Ok(())
+}
+
+/// Call Heatzy control API to switch the radiator mode.
+async fn set_heatzy_mode(
+    heatzy_application_id: &str,
+    heatzy_token: &str,
+    did: &str,
+    mode: RadiatorMode,
+) -> anyhow::Result<()> {
+    let h_mode = match mode {
+        RadiatorMode::CFT => 0,
+        RadiatorMode::ECO => 1,
+        RadiatorMode::FRO => 2,
+        RadiatorMode::STOP => 3,
+    };
+
+    let data = serde_json::json!({
+        "attrs": {
+            "mode": h_mode
+        }
+    });
+
+    let url = format!("https://euapi.gizwits.com/app/control/{}", did);
+
+    let mut custom_header = header::HeaderMap::new();
+    custom_header.insert(
+        header::USER_AGENT,
+        header::HeaderValue::from_static("reqwest"),
+    );
+    custom_header.insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("application/json"),
+    );
+    custom_header.insert(
+        "X-Gizwits-Application-Id",
+        heatzy_application_id.parse().unwrap(),
+    );
+    custom_header.insert("X-Gizwits-User-token", heatzy_token.parse().unwrap());
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .headers(custom_header)
+        .json(&data)
+        .send()
+        .await?;
+
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(anyhow!("Heatzy error status: {}", response.status()))
+    }
+}
+
+/// Hysteresis copied from existing regulator logic.
+fn determine_action(t_current: f64, tc: f32) -> RadiatorAction {
+    if t_current < tc as f64 - 0.3f64 {
+        RadiatorAction::On
+    } else if t_current > tc as f64 + 0.3f64 {
+        RadiatorAction::Off
+    } else {
+        RadiatorAction::NoAction
+    }
+}
+
+fn mode_from_str(mode: &str) -> anyhow::Result<RadiatorMode> {
+    match mode {
+        "CFT" => Ok(RadiatorMode::CFT),
+        "ECO" => Ok(RadiatorMode::ECO),
+        "FRO" => Ok(RadiatorMode::FRO),
+        "STOP" => Ok(RadiatorMode::STOP),
+        _ => Err(anyhow!("Unknown mode [{}]", mode)),
+    }
+}
+
+fn mode_as_str(mode: RadiatorMode) -> &'static str {
+    match mode {
+        RadiatorMode::CFT => "CFT",
+        RadiatorMode::ECO => "ECO",
+        RadiatorMode::FRO => "FRO",
+        RadiatorMode::STOP => "STOP",
+    }
+}
+
+fn internal_error<E: std::fmt::Display>(err: E) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+}

--- a/radiator-api/src/main.rs
+++ b/radiator-api/src/main.rs
@@ -1,102 +1,18 @@
-use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::process::exit;
 
-use anyhow::anyhow;
-use ava_toolkit::device_message::RadiatorMode;
-use axum::extract::State;
-use axum::http::StatusCode;
 use axum::routing::post;
-use axum::{Json, Router};
-use chrono::Local;
+use axum::Router;
 use common_config::conf_reader::{read_config, read_env};
 use common_config::properties::{get_prop_pg_connect_string, get_prop_value, set_prop_values};
 use log::{error, info};
-use reqwest::header;
-use serde_derive::{Deserialize, Serialize};
-use serde_json::Value;
-use tokio_postgres::NoTls;
 
-const RAD_SALON: &str = "external/rad_salon";
-const RAD_BUREAU: &str = "external/rad_bureau";
-const RAD_COULOIR: &str = "external/rad_couloir";
-const RAD_CHAMBRE: &str = "external/rad_chambre";
-
-const CURRENT_REGULATION_MAP_SQL: &str = r"SELECT id, starting_time, ending_time, end_the_next_day, boost, regulation_map::text AS regulation_map_json, ts_created
-FROM public.heating_plan
-WHERE boost = false
-AND (
-    (
-        end_the_next_day = true
-        AND (
-            (starting_time <= $1)
-            OR ($1 < ending_time)
-        )
-    )
-    OR (
-        end_the_next_day = false
-        AND starting_time <= $1
-        AND $1 < ending_time
-    )
-)
-ORDER BY ts_created DESC
-LIMIT 1";
-
-const LATEST_RADIATOR_STATE_SQL: &str = r"SELECT DISTINCT ON (device_name) device_name, state, ts_create
-FROM public.device_state_history
-WHERE device_name LIKE 'external/rad_%'
-ORDER BY device_name, ts_create DESC";
-
-#[derive(Clone)]
-struct AppState {
-    db_url: String,
-    heatzy_application_id: String,
-    heatzy_token: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct UpdateRadiatorRequest {
-    chambre: f64,
-    salon: f64,
-    couloir: f64,
-    bureau: f64,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct UpdateRadiatorResponse {
-    updated_radiators: Vec<UpdatedRadiator>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct UpdatedRadiator {
-    radiator: String,
-    status: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RadiatorState {
-    mode: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RegulationMap {
-    tc_bureau: f32,
-    tc_salon_1: f32,
-    tc_salon_2: f32,
-    tc_chambre_1: f32,
-    tc_couloir: f32,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-enum RadiatorAction {
-    On,
-    Off,
-    NoAction,
-}
+mod api;
 
 #[tokio::main]
 async fn main() {
+    // 1) Logging initialization.
     env::set_var(
         "RUST_LOG",
         env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
@@ -108,13 +24,8 @@ async fn main() {
     const PROJECT_CODE: &str = "radiator-api";
     const VAR_NAME: &str = "AVA_ENV";
 
+    // 2) Load service configuration from AVA config system.
     let o_config_file = read_env(VAR_NAME);
-
-    info!(
-        "Config file using PROJECT_CODE={} VAR_NAME={}",
-        PROJECT_CODE, VAR_NAME
-    );
-
     let props = read_config(
         PROJECT_CODE,
         &o_config_file,
@@ -125,6 +36,8 @@ async fn main() {
     let port = read_props_or_die("server.port")
         .parse::<u16>()
         .unwrap_or(30055);
+
+    // 3) Build shared app state consumed by request handlers.
     let (db_url, _) = match get_prop_pg_connect_string() {
         Ok(v) => v,
         Err(e) => {
@@ -133,264 +46,21 @@ async fn main() {
         }
     };
 
-    let app_state = AppState {
+    let app_state = api::AppState {
         db_url,
         heatzy_application_id: read_props_or_die("heatzy.application.id"),
         heatzy_token: read_props_or_die("heatzy.token"),
     };
 
+    // 4) Start HTTP server with a single business endpoint.
     let app = Router::new()
-        .route("/update-radiator", post(update_radiator))
+        .route("/update-radiator", post(api::update_radiator))
         .with_state(app_state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     info!("radiator-api listening on {}", addr);
     axum::serve(listener, app).await.unwrap();
-}
-
-async fn update_radiator(
-    State(state): State<AppState>,
-    Json(payload): Json<UpdateRadiatorRequest>,
-) -> Result<Json<UpdateRadiatorResponse>, (StatusCode, String)> {
-    let (client, connection) = tokio_postgres::connect(&state.db_url, NoTls)
-        .await
-        .map_err(internal_error)?;
-
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            error!("Database connection error: {}", e);
-        }
-    });
-
-    let regulation_map = get_current_regulation_map(&client)
-        .await
-        .map_err(internal_error)?;
-
-    let current_states = get_latest_radiator_states(&client)
-        .await
-        .map_err(internal_error)?;
-
-    let room_temperatures = HashMap::from([
-        (RAD_BUREAU.to_string(), payload.bureau),
-        (RAD_CHAMBRE.to_string(), payload.chambre),
-        (RAD_COULOIR.to_string(), payload.couloir),
-        (RAD_SALON.to_string(), payload.salon),
-    ]);
-
-    let room_targets = HashMap::from([
-        (RAD_BUREAU.to_string(), regulation_map.tc_bureau),
-        (RAD_CHAMBRE.to_string(), regulation_map.tc_chambre_1),
-        (RAD_COULOIR.to_string(), regulation_map.tc_couloir),
-        (RAD_SALON.to_string(), regulation_map.tc_salon_1),
-    ]);
-
-    let did_by_radiator = HashMap::from([
-        (RAD_SALON.to_string(), "3wHa7Ja50MhfShUxcmOqvT"),
-        (RAD_COULOIR.to_string(), "JUVo7yMFQtdfZhi25Vo4Bu"),
-        (RAD_CHAMBRE.to_string(), "LNENiFG0MeReR9WtxMebYB"),
-        (RAD_BUREAU.to_string(), "mO7E2B49G1BS8R77UmWIjk"),
-    ]);
-
-    let mut updated_radiators = Vec::new();
-
-    for radiator in [RAD_BUREAU, RAD_CHAMBRE, RAD_COULOIR, RAD_SALON] {
-        let current_mode = current_states
-            .get(radiator)
-            .ok_or_else(|| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Missing current state in DB for radiator [{}]", radiator),
-                )
-            })?
-            .clone();
-
-        if current_mode == RadiatorMode::ECO {
-            info!("{} in ECO mode => no action", radiator);
-            continue;
-        }
-
-        let t_current = *room_temperatures.get(radiator).ok_or_else(|| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Missing temperature for radiator [{}]", radiator),
-            )
-        })?;
-
-        let t_target = *room_targets.get(radiator).ok_or_else(|| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Missing target temperature for radiator [{}]", radiator),
-            )
-        })?;
-
-        let action = determine_action(t_current, t_target);
-        let next_mode = match action {
-            RadiatorAction::On => Some(RadiatorMode::CFT),
-            RadiatorAction::Off => Some(RadiatorMode::STOP),
-            RadiatorAction::NoAction => None,
-        };
-
-        if let Some(next_mode) = next_mode {
-            if next_mode != current_mode {
-                let did = did_by_radiator
-                    .get(radiator)
-                    .ok_or_else(|| internal_error(anyhow!("Missing DID mapping")))?;
-
-                set_heatzy_mode(
-                    &state.heatzy_application_id,
-                    &state.heatzy_token,
-                    did,
-                    next_mode,
-                )
-                .await
-                .map_err(internal_error)?;
-
-                save_radiator_state(&client, radiator, next_mode)
-                    .await
-                    .map_err(internal_error)?;
-
-                updated_radiators.push(UpdatedRadiator {
-                    radiator: radiator.to_string(),
-                    status: mode_as_str(next_mode).to_string(),
-                });
-            }
-        }
-    }
-
-    Ok(Json(UpdateRadiatorResponse { updated_radiators }))
-}
-
-async fn get_current_regulation_map(
-    client: &tokio_postgres::Client,
-) -> anyhow::Result<RegulationMap> {
-    let local_time = Local::now().time().format("%H:%M:%S").to_string();
-
-    let row = client
-        .query_opt(CURRENT_REGULATION_MAP_SQL, &[&local_time])
-        .await?
-        .ok_or_else(|| anyhow!("No current regulation map found"))?;
-
-    let reg_json: String = row.try_get("regulation_map_json")?;
-    let reg: Value = serde_json::from_str(&reg_json)?;
-    let reg_map: RegulationMap = serde_json::from_value(reg)?;
-    Ok(reg_map)
-}
-
-async fn get_latest_radiator_states(
-    client: &tokio_postgres::Client,
-) -> anyhow::Result<HashMap<String, RadiatorMode>> {
-    let rows = client.query(LATEST_RADIATOR_STATE_SQL, &[]).await?;
-
-    let mut states = HashMap::new();
-    for row in rows {
-        let device_name: String = row.try_get("device_name")?;
-        let state_json: String = row.try_get("state")?;
-        let state: RadiatorState = serde_json::from_str(&state_json)?;
-        states.insert(device_name, mode_from_str(&state.mode)?);
-    }
-
-    Ok(states)
-}
-
-async fn save_radiator_state(
-    client: &tokio_postgres::Client,
-    radiator: &str,
-    mode: RadiatorMode,
-) -> anyhow::Result<()> {
-    let state = serde_json::to_string(&RadiatorState {
-        mode: mode_as_str(mode).to_string(),
-    })?;
-
-    let query = r#"INSERT INTO public.device_state_history (device_name, state, ts_create)
-VALUES($1, $2, timezone('UTC', current_timestamp))"#;
-
-    client.execute(query, &[&radiator, &state]).await?;
-    Ok(())
-}
-
-async fn set_heatzy_mode(
-    heatzy_application_id: &str,
-    heatzy_token: &str,
-    did: &str,
-    mode: RadiatorMode,
-) -> anyhow::Result<()> {
-    let h_mode = match mode {
-        RadiatorMode::CFT => 0,
-        RadiatorMode::ECO => 1,
-        RadiatorMode::FRO => 2,
-        RadiatorMode::STOP => 3,
-    };
-
-    let data = serde_json::json!({
-        "attrs": {
-            "mode": h_mode
-        }
-    });
-
-    let url = format!("https://euapi.gizwits.com/app/control/{}", did);
-
-    let mut custom_header = header::HeaderMap::new();
-    custom_header.insert(
-        header::USER_AGENT,
-        header::HeaderValue::from_static("reqwest"),
-    );
-    custom_header.insert(
-        header::CONTENT_TYPE,
-        header::HeaderValue::from_static("application/json"),
-    );
-    custom_header.insert(
-        "X-Gizwits-Application-Id",
-        heatzy_application_id.parse().unwrap(),
-    );
-    custom_header.insert("X-Gizwits-User-token", heatzy_token.parse().unwrap());
-
-    let client = reqwest::Client::new();
-    let response = client
-        .post(url)
-        .headers(custom_header)
-        .json(&data)
-        .send()
-        .await?;
-
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        Err(anyhow!("Heatzy error status: {}", response.status()))
-    }
-}
-
-fn determine_action(t_current: f64, tc: f32) -> RadiatorAction {
-    if t_current < tc as f64 - 0.3f64 {
-        RadiatorAction::On
-    } else if t_current > tc as f64 + 0.3f64 {
-        RadiatorAction::Off
-    } else {
-        RadiatorAction::NoAction
-    }
-}
-
-fn mode_from_str(mode: &str) -> anyhow::Result<RadiatorMode> {
-    match mode {
-        "CFT" => Ok(RadiatorMode::CFT),
-        "ECO" => Ok(RadiatorMode::ECO),
-        "FRO" => Ok(RadiatorMode::FRO),
-        "STOP" => Ok(RadiatorMode::STOP),
-        _ => Err(anyhow!("Unknown mode [{}]", mode)),
-    }
-}
-
-fn mode_as_str(mode: RadiatorMode) -> &'static str {
-    match mode {
-        RadiatorMode::CFT => "CFT",
-        RadiatorMode::ECO => "ECO",
-        RadiatorMode::FRO => "FRO",
-        RadiatorMode::STOP => "STOP",
-    }
-}
-
-fn internal_error<E: std::fmt::Display>(err: E) -> (StatusCode, String) {
-    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
 }
 
 fn read_props_or_die(property_name: &str) -> String {

--- a/radiator-api/src/main.rs
+++ b/radiator-api/src/main.rs
@@ -1,0 +1,404 @@
+use std::collections::HashMap;
+use std::env;
+use std::net::SocketAddr;
+use std::process::exit;
+
+use anyhow::anyhow;
+use ava_toolkit::device_message::RadiatorMode;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::post;
+use axum::{Json, Router};
+use chrono::Local;
+use common_config::conf_reader::{read_config, read_env};
+use common_config::properties::{get_prop_pg_connect_string, get_prop_value, set_prop_values};
+use log::{error, info};
+use reqwest::header;
+use serde_derive::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio_postgres::NoTls;
+
+const RAD_SALON: &str = "external/rad_salon";
+const RAD_BUREAU: &str = "external/rad_bureau";
+const RAD_COULOIR: &str = "external/rad_couloir";
+const RAD_CHAMBRE: &str = "external/rad_chambre";
+
+const CURRENT_REGULATION_MAP_SQL: &str = r"SELECT id, starting_time, ending_time, end_the_next_day, boost, regulation_map::text AS regulation_map_json, ts_created
+FROM public.heating_plan
+WHERE boost = false
+AND (
+    (
+        end_the_next_day = true
+        AND (
+            (starting_time <= $1)
+            OR ($1 < ending_time)
+        )
+    )
+    OR (
+        end_the_next_day = false
+        AND starting_time <= $1
+        AND $1 < ending_time
+    )
+)
+ORDER BY ts_created DESC
+LIMIT 1";
+
+const LATEST_RADIATOR_STATE_SQL: &str = r"SELECT DISTINCT ON (device_name) device_name, state, ts_create
+FROM public.device_state_history
+WHERE device_name LIKE 'external/rad_%'
+ORDER BY device_name, ts_create DESC";
+
+#[derive(Clone)]
+struct AppState {
+    db_url: String,
+    heatzy_application_id: String,
+    heatzy_token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdateRadiatorRequest {
+    chambre: f64,
+    salon: f64,
+    couloir: f64,
+    bureau: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdateRadiatorResponse {
+    updated_radiators: Vec<UpdatedRadiator>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdatedRadiator {
+    radiator: String,
+    status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RadiatorState {
+    mode: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RegulationMap {
+    tc_bureau: f32,
+    tc_salon_1: f32,
+    tc_salon_2: f32,
+    tc_chambre_1: f32,
+    tc_couloir: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum RadiatorAction {
+    On,
+    Off,
+    NoAction,
+}
+
+#[tokio::main]
+async fn main() {
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
+    env_logger::init();
+
+    info!("Starting AVA radiator-api 0.1.0");
+
+    const PROJECT_CODE: &str = "radiator-api";
+    const VAR_NAME: &str = "AVA_ENV";
+
+    let o_config_file = read_env(VAR_NAME);
+
+    info!(
+        "Config file using PROJECT_CODE={} VAR_NAME={}",
+        PROJECT_CODE, VAR_NAME
+    );
+
+    let props = read_config(
+        PROJECT_CODE,
+        &o_config_file,
+        &Some("AVA_CLUSTER_PROFILE".to_string()),
+    );
+    set_prop_values(props);
+
+    let port = read_props_or_die("server.port")
+        .parse::<u16>()
+        .unwrap_or(30055);
+    let (db_url, _) = match get_prop_pg_connect_string() {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Cannot read database properties: {}", e);
+            exit(-64);
+        }
+    };
+
+    let app_state = AppState {
+        db_url,
+        heatzy_application_id: read_props_or_die("heatzy.application.id"),
+        heatzy_token: read_props_or_die("heatzy.token"),
+    };
+
+    let app = Router::new()
+        .route("/update-radiator", post(update_radiator))
+        .with_state(app_state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    info!("radiator-api listening on {}", addr);
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn update_radiator(
+    State(state): State<AppState>,
+    Json(payload): Json<UpdateRadiatorRequest>,
+) -> Result<Json<UpdateRadiatorResponse>, (StatusCode, String)> {
+    let (client, connection) = tokio_postgres::connect(&state.db_url, NoTls)
+        .await
+        .map_err(internal_error)?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            error!("Database connection error: {}", e);
+        }
+    });
+
+    let regulation_map = get_current_regulation_map(&client)
+        .await
+        .map_err(internal_error)?;
+
+    let current_states = get_latest_radiator_states(&client)
+        .await
+        .map_err(internal_error)?;
+
+    let room_temperatures = HashMap::from([
+        (RAD_BUREAU.to_string(), payload.bureau),
+        (RAD_CHAMBRE.to_string(), payload.chambre),
+        (RAD_COULOIR.to_string(), payload.couloir),
+        (RAD_SALON.to_string(), payload.salon),
+    ]);
+
+    let room_targets = HashMap::from([
+        (RAD_BUREAU.to_string(), regulation_map.tc_bureau),
+        (RAD_CHAMBRE.to_string(), regulation_map.tc_chambre_1),
+        (RAD_COULOIR.to_string(), regulation_map.tc_couloir),
+        (RAD_SALON.to_string(), regulation_map.tc_salon_1),
+    ]);
+
+    let did_by_radiator = HashMap::from([
+        (RAD_SALON.to_string(), "3wHa7Ja50MhfShUxcmOqvT"),
+        (RAD_COULOIR.to_string(), "JUVo7yMFQtdfZhi25Vo4Bu"),
+        (RAD_CHAMBRE.to_string(), "LNENiFG0MeReR9WtxMebYB"),
+        (RAD_BUREAU.to_string(), "mO7E2B49G1BS8R77UmWIjk"),
+    ]);
+
+    let mut updated_radiators = Vec::new();
+
+    for radiator in [RAD_BUREAU, RAD_CHAMBRE, RAD_COULOIR, RAD_SALON] {
+        let current_mode = current_states
+            .get(radiator)
+            .ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Missing current state in DB for radiator [{}]", radiator),
+                )
+            })?
+            .clone();
+
+        if current_mode == RadiatorMode::ECO {
+            info!("{} in ECO mode => no action", radiator);
+            continue;
+        }
+
+        let t_current = *room_temperatures.get(radiator).ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Missing temperature for radiator [{}]", radiator),
+            )
+        })?;
+
+        let t_target = *room_targets.get(radiator).ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Missing target temperature for radiator [{}]", radiator),
+            )
+        })?;
+
+        let action = determine_action(t_current, t_target);
+        let next_mode = match action {
+            RadiatorAction::On => Some(RadiatorMode::CFT),
+            RadiatorAction::Off => Some(RadiatorMode::STOP),
+            RadiatorAction::NoAction => None,
+        };
+
+        if let Some(next_mode) = next_mode {
+            if next_mode != current_mode {
+                let did = did_by_radiator
+                    .get(radiator)
+                    .ok_or_else(|| internal_error(anyhow!("Missing DID mapping")))?;
+
+                set_heatzy_mode(
+                    &state.heatzy_application_id,
+                    &state.heatzy_token,
+                    did,
+                    next_mode,
+                )
+                .await
+                .map_err(internal_error)?;
+
+                save_radiator_state(&client, radiator, next_mode)
+                    .await
+                    .map_err(internal_error)?;
+
+                updated_radiators.push(UpdatedRadiator {
+                    radiator: radiator.to_string(),
+                    status: mode_as_str(next_mode).to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(Json(UpdateRadiatorResponse { updated_radiators }))
+}
+
+async fn get_current_regulation_map(
+    client: &tokio_postgres::Client,
+) -> anyhow::Result<RegulationMap> {
+    let local_time = Local::now().time().format("%H:%M:%S").to_string();
+
+    let row = client
+        .query_opt(CURRENT_REGULATION_MAP_SQL, &[&local_time])
+        .await?
+        .ok_or_else(|| anyhow!("No current regulation map found"))?;
+
+    let reg_json: String = row.try_get("regulation_map_json")?;
+    let reg: Value = serde_json::from_str(&reg_json)?;
+    let reg_map: RegulationMap = serde_json::from_value(reg)?;
+    Ok(reg_map)
+}
+
+async fn get_latest_radiator_states(
+    client: &tokio_postgres::Client,
+) -> anyhow::Result<HashMap<String, RadiatorMode>> {
+    let rows = client.query(LATEST_RADIATOR_STATE_SQL, &[]).await?;
+
+    let mut states = HashMap::new();
+    for row in rows {
+        let device_name: String = row.try_get("device_name")?;
+        let state_json: String = row.try_get("state")?;
+        let state: RadiatorState = serde_json::from_str(&state_json)?;
+        states.insert(device_name, mode_from_str(&state.mode)?);
+    }
+
+    Ok(states)
+}
+
+async fn save_radiator_state(
+    client: &tokio_postgres::Client,
+    radiator: &str,
+    mode: RadiatorMode,
+) -> anyhow::Result<()> {
+    let state = serde_json::to_string(&RadiatorState {
+        mode: mode_as_str(mode).to_string(),
+    })?;
+
+    let query = r#"INSERT INTO public.device_state_history (device_name, state, ts_create)
+VALUES($1, $2, timezone('UTC', current_timestamp))"#;
+
+    client.execute(query, &[&radiator, &state]).await?;
+    Ok(())
+}
+
+async fn set_heatzy_mode(
+    heatzy_application_id: &str,
+    heatzy_token: &str,
+    did: &str,
+    mode: RadiatorMode,
+) -> anyhow::Result<()> {
+    let h_mode = match mode {
+        RadiatorMode::CFT => 0,
+        RadiatorMode::ECO => 1,
+        RadiatorMode::FRO => 2,
+        RadiatorMode::STOP => 3,
+    };
+
+    let data = serde_json::json!({
+        "attrs": {
+            "mode": h_mode
+        }
+    });
+
+    let url = format!("https://euapi.gizwits.com/app/control/{}", did);
+
+    let mut custom_header = header::HeaderMap::new();
+    custom_header.insert(
+        header::USER_AGENT,
+        header::HeaderValue::from_static("reqwest"),
+    );
+    custom_header.insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("application/json"),
+    );
+    custom_header.insert(
+        "X-Gizwits-Application-Id",
+        heatzy_application_id.parse().unwrap(),
+    );
+    custom_header.insert("X-Gizwits-User-token", heatzy_token.parse().unwrap());
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .headers(custom_header)
+        .json(&data)
+        .send()
+        .await?;
+
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(anyhow!("Heatzy error status: {}", response.status()))
+    }
+}
+
+fn determine_action(t_current: f64, tc: f32) -> RadiatorAction {
+    if t_current < tc as f64 - 0.3f64 {
+        RadiatorAction::On
+    } else if t_current > tc as f64 + 0.3f64 {
+        RadiatorAction::Off
+    } else {
+        RadiatorAction::NoAction
+    }
+}
+
+fn mode_from_str(mode: &str) -> anyhow::Result<RadiatorMode> {
+    match mode {
+        "CFT" => Ok(RadiatorMode::CFT),
+        "ECO" => Ok(RadiatorMode::ECO),
+        "FRO" => Ok(RadiatorMode::FRO),
+        "STOP" => Ok(RadiatorMode::STOP),
+        _ => Err(anyhow!("Unknown mode [{}]", mode)),
+    }
+}
+
+fn mode_as_str(mode: RadiatorMode) -> &'static str {
+    match mode {
+        RadiatorMode::CFT => "CFT",
+        RadiatorMode::ECO => "ECO",
+        RadiatorMode::FRO => "FRO",
+        RadiatorMode::STOP => "STOP",
+    }
+}
+
+fn internal_error<E: std::fmt::Display>(err: E) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+}
+
+fn read_props_or_die(property_name: &str) -> String {
+    match get_prop_value(property_name) {
+        Ok(value) => value,
+        Err(e) => {
+            error!("{}", e);
+            panic!("Cannot find property [{}]", property_name);
+        }
+    }
+}

--- a/regulator/src/external_computing.rs
+++ b/regulator/src/external_computing.rs
@@ -5,7 +5,6 @@ use std::time::SystemTime;
 use chrono::{DateTime, Utc};
 use common_config::properties::get_prop_pg_connect_string;
 use log::{error, info};
-use serde_derive::{Deserialize, Serialize};
 use tokio_postgres::NoTls;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -88,18 +87,6 @@ pub (crate) fn determine_action(t_current: f64, tc: f32) -> RadiatorAction {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-struct Attribute {
-    mode: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct DevData {
-    did: String,
-    updated_at: u32,
-    attr: Attribute,
-}
-
 // async fn get_mode(heatzy_application_id: &str,  heatzy_token: &str, did: &str) -> anyhow::Result<RadiatorMode> {
 //     let mut custom_header = header::HeaderMap::new();
 //     custom_header.insert(header::USER_AGENT, header::HeaderValue::from_static("reqwest"));
@@ -141,4 +128,3 @@ struct DevData {
 //         Err(anyhow!("{:?}", response))
 //     }
 // }
-


### PR DESCRIPTION
### Motivation
- Ajouter un service HTTP simple pour appliquer la logique de régulation existante sans utiliser MQTT, exposant une action ponctuelle `POST /update-radiator` qui prend les températures des 4 pièces et met à jour les radiateurs via l'API Heatzy et la base de données.

### Description
- Ajout d'un nouveau workspace member `radiator-api` avec `radiator-api/Cargo.toml` et l'implémentation principale dans `radiator-api/src/main.rs`, et enregistrement dans le `Cargo.toml` racine et `Cargo.lock`.
- Implémentation d'un endpoint `POST /update-radiator` qui accepte un JSON `{ chambre, salon, couloir, bureau }` (`UpdateRadiatorRequest`) et retourne la liste des radiateurs modifiés (`UpdateRadiatorResponse`).
- Reprise de la logique métier existante : lecture du `heating_plan` courant (`get_current_regulation_map`), lecture des derniers états des radiateurs depuis `device_state_history`, calcul d'action avec hystérésis `±0.3` (`determine_action`), saut d'action si le radiateur est en `ECO`, et mapping DID/appel Heatzy (mêmes DIDs que `radiator-ctrl`) lorsqu'un changement est nécessaire.
- Persistance du nouvel état dans la table `device_state_history` après succès de l'appel Heatzy et renvoi du JSON des radiateurs effectivement mis à jour ; configuration et accès à la BDD fournis via `common-config` (`get_prop_pg_connect_string` / `read_config`).
- Correction SQL/typage pour compatibilité `tokio-postgres` en lisant `regulation_map` via `regulation_map::text AS regulation_map_json` et en passant l'heure locale au SQL comme chaîne au lieu de `NaiveTime` pour éviter les erreurs `ToSql`/`FromSql` lors du build.

### Testing
- Exécution de `cargo check -p radiator-api` jusqu'à obtenir une compilation sans erreur, la première passe a révélé des erreurs de typage SQL qui ont été corrigées et la passe finale a réussi.
- Exécution de `cargo fmt` qui a été lancée et n'a produit d'erreur.
- Ré-exécution de `cargo check -p radiator-api` après formatage a abouti avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1f568768c832d95c226da1004962d)