### PR TITLE
Refresh Heatzy token on auth failure and persist runtime token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "common-config",
  "env_logger",
  "log",
+ "radiator-toolkit",
  "reqwest",
  "serde",
  "serde_derive",
@@ -2038,12 +2039,24 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
- "reqwest",
+ "radiator-toolkit",
  "rumqttc",
  "serde",
  "serde_derive",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "radiator-toolkit"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ava-toolkit",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "radiator-ctrl",
     "dashboard", "ava-toolkit",
     "radiator-api",
+    "radiator-toolkit",
 ]
 
 [workspace.dependencies]

--- a/radiator-api/Cargo.toml
+++ b/radiator-api/Cargo.toml
@@ -18,3 +18,4 @@ tokio-postgres = { workspace = true }
 
 ava-toolkit = { path = "../ava-toolkit" }
 common-config = { path = "../common-config" }
+radiator-toolkit = { path = "../radiator-toolkit" }

--- a/radiator-api/src/api.rs
+++ b/radiator-api/src/api.rs
@@ -6,10 +6,12 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use chrono::{Local, NaiveTime};
+use common_config::properties::set_prop_value;
 use log::{error, info};
 use reqwest::header;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::{Arc, RwLock};
 use tokio_postgres::NoTls;
 
 const RAD_SALON: &str = "external/rad_salon";
@@ -51,7 +53,9 @@ ORDER BY device_name, ts_create DESC";
 pub struct AppState {
     pub db_url: String,
     pub heatzy_application_id: String,
-    pub heatzy_token: String,
+    pub heatzy_token: Arc<RwLock<String>>,
+    pub heatzy_username: String,
+    pub heatzy_password: String,
 }
 
 /// Payload expected by POST /update-radiator.
@@ -172,7 +176,10 @@ pub async fn update_radiator(
 
         // Business rule inherited from regulator: ECO mode is manually forced and must not be overridden.
         if current_mode == RadiatorMode::ECO {
-            info!("\t🧊 Radiator {} is in ECO mode, no override will be applied", radiator);
+            info!(
+                "\t🧊 Radiator {} is in ECO mode, no override will be applied",
+                radiator
+            );
             continue;
         }
 
@@ -217,10 +224,15 @@ pub async fn update_radiator(
                     .get(radiator)
                     .ok_or_else(|| internal_error(anyhow!("Missing DID mapping")))?;
 
-                info!("\t📡 Send Heatzy command for radiator {} with DID {}", radiator, did);
+                info!(
+                    "\t📡 Send Heatzy command for radiator {} with DID {}",
+                    radiator, did
+                );
                 set_heatzy_mode(
                     &state.heatzy_application_id,
-                    &state.heatzy_token,
+                    &state.heatzy_username,
+                    &state.heatzy_password,
+                    state.heatzy_token.clone(),
                     did,
                     next_mode,
                 )
@@ -335,10 +347,54 @@ VALUES($1, $2, timezone('UTC', current_timestamp))"#;
 /// Call Heatzy control API to switch the radiator mode.
 async fn set_heatzy_mode(
     heatzy_application_id: &str,
-    heatzy_token: &str,
+    heatzy_username: &str,
+    heatzy_password: &str,
+    heatzy_token: Arc<RwLock<String>>,
     did: &str,
     mode: RadiatorMode,
 ) -> anyhow::Result<()> {
+    let current_token = {
+        let guard = heatzy_token
+            .read()
+            .map_err(|_| anyhow!("Cannot read current Heatzy token"))?;
+        guard.clone()
+    };
+
+    info!("Using existing Heatzy token for control API call");
+    match set_heatzy_mode_with_token(heatzy_application_id, &current_token, did, mode).await {
+        Ok(()) => Ok(()),
+        Err(HeatzyCallError::HttpStatus(status)) if is_auth_error(status) => {
+            info!("🔄 Reconnecting to Heatzy to refresh token");
+            info!(
+                "Heatzy token rejected with status {}, trying login before retrying command",
+                status
+            );
+            let refreshed_token =
+                login_heatzy(heatzy_application_id, heatzy_username, heatzy_password).await?;
+
+            {
+                let mut guard = heatzy_token
+                    .write()
+                    .map_err(|_| anyhow!("Cannot update Heatzy token"))?;
+                *guard = refreshed_token.clone();
+            }
+            set_prop_value("heatzy.token", &refreshed_token);
+            info!("Heatzy token refreshed and saved into runtime configuration");
+
+            set_heatzy_mode_with_token(heatzy_application_id, &refreshed_token, did, mode)
+                .await
+                .map_err(|e| anyhow!("Heatzy error after relogin: {}", e))
+        }
+        Err(e) => Err(anyhow!("Heatzy error: {}", e)),
+    }
+}
+
+async fn set_heatzy_mode_with_token(
+    heatzy_application_id: &str,
+    heatzy_token: &str,
+    did: &str,
+    mode: RadiatorMode,
+) -> Result<(), HeatzyCallError> {
     let h_mode = match mode {
         RadiatorMode::CFT => 0,
         RadiatorMode::ECO => 1,
@@ -375,12 +431,80 @@ async fn set_heatzy_mode(
         .headers(custom_header)
         .json(&data)
         .send()
-        .await?;
+        .await
+        .map_err(HeatzyCallError::Request)?;
 
     if response.status().is_success() {
         Ok(())
     } else {
-        Err(anyhow!("Heatzy error status: {}", response.status()))
+        Err(HeatzyCallError::HttpStatus(response.status()))
+    }
+}
+
+async fn login_heatzy(
+    heatzy_application_id: &str,
+    heatzy_username: &str,
+    heatzy_password: &str,
+) -> anyhow::Result<String> {
+    let url = "https://api.gizwits.com/app/login";
+    let body = serde_json::json!({
+        "username": heatzy_username,
+        "password": heatzy_password,
+    });
+
+    let mut custom_header = header::HeaderMap::new();
+    custom_header.insert(
+        header::USER_AGENT,
+        header::HeaderValue::from_static("reqwest"),
+    );
+    custom_header.insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("application/json"),
+    );
+    custom_header.insert(
+        "X-Gizwits-Application-Id",
+        heatzy_application_id.parse().unwrap(),
+    );
+
+    #[derive(Debug, Deserialize)]
+    struct LoginResponse {
+        token: String,
+    }
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .headers(custom_header)
+        .json(&body)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "Heatzy login failed with status {}",
+            response.status()
+        ));
+    }
+
+    let login_response: LoginResponse = response.json().await?;
+    Ok(login_response.token)
+}
+
+fn is_auth_error(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
+}
+
+enum HeatzyCallError {
+    Request(reqwest::Error),
+    HttpStatus(reqwest::StatusCode),
+}
+
+impl std::fmt::Display for HeatzyCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HeatzyCallError::Request(e) => write!(f, "request error: {}", e),
+            HeatzyCallError::HttpStatus(status) => write!(f, "status {}", status),
+        }
     }
 }
 

--- a/radiator-api/src/api.rs
+++ b/radiator-api/src/api.rs
@@ -8,7 +8,7 @@ use axum::Json;
 use chrono::{Local, NaiveTime};
 use common_config::properties::set_prop_value;
 use log::{error, info};
-use reqwest::header;
+use radiator_toolkit::HeatzyClient;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::{Arc, RwLock};
@@ -353,159 +353,22 @@ async fn set_heatzy_mode(
     did: &str,
     mode: RadiatorMode,
 ) -> anyhow::Result<()> {
-    let current_token = {
-        let guard = heatzy_token
-            .read()
-            .map_err(|_| anyhow!("Cannot read current Heatzy token"))?;
-        guard.clone()
-    };
+    let client = HeatzyClient::new(
+        heatzy_application_id,
+        heatzy_username,
+        heatzy_password,
+        heatzy_token,
+    );
+    let previous_token = client.current_token()?;
 
-    info!("Using existing Heatzy token for control API call");
-    match set_heatzy_mode_with_token(heatzy_application_id, &current_token, did, mode).await {
-        Ok(()) => Ok(()),
-        Err(HeatzyCallError::HttpStatus(status)) if is_auth_error(status) => {
-            info!("🔄 Reconnecting to Heatzy to refresh token");
-            info!(
-                "Heatzy token rejected with status {}, trying login before retrying command",
-                status
-            );
-            let refreshed_token =
-                login_heatzy(heatzy_application_id, heatzy_username, heatzy_password).await?;
+    client.set_mode(did, mode).await?;
 
-            {
-                let mut guard = heatzy_token
-                    .write()
-                    .map_err(|_| anyhow!("Cannot update Heatzy token"))?;
-                *guard = refreshed_token.clone();
-            }
-            set_prop_value("heatzy.token", &refreshed_token);
-            info!("Heatzy token refreshed and saved into runtime configuration");
-
-            set_heatzy_mode_with_token(heatzy_application_id, &refreshed_token, did, mode)
-                .await
-                .map_err(|e| anyhow!("Heatzy error after relogin: {}", e))
-        }
-        Err(e) => Err(anyhow!("Heatzy error: {}", e)),
+    let current_token = client.current_token()?;
+    if current_token != previous_token {
+        set_prop_value("heatzy.token", &current_token);
+        info!("Heatzy token refreshed and saved into runtime configuration");
     }
-}
-
-async fn set_heatzy_mode_with_token(
-    heatzy_application_id: &str,
-    heatzy_token: &str,
-    did: &str,
-    mode: RadiatorMode,
-) -> Result<(), HeatzyCallError> {
-    let h_mode = match mode {
-        RadiatorMode::CFT => 0,
-        RadiatorMode::ECO => 1,
-        RadiatorMode::FRO => 2,
-        RadiatorMode::STOP => 3,
-    };
-
-    let data = serde_json::json!({
-        "attrs": {
-            "mode": h_mode
-        }
-    });
-
-    let url = format!("https://euapi.gizwits.com/app/control/{}", did);
-
-    let mut custom_header = header::HeaderMap::new();
-    custom_header.insert(
-        header::USER_AGENT,
-        header::HeaderValue::from_static("reqwest"),
-    );
-    custom_header.insert(
-        header::CONTENT_TYPE,
-        header::HeaderValue::from_static("application/json"),
-    );
-    custom_header.insert(
-        "X-Gizwits-Application-Id",
-        heatzy_application_id.parse().unwrap(),
-    );
-    custom_header.insert("X-Gizwits-User-token", heatzy_token.parse().unwrap());
-
-    let client = reqwest::Client::new();
-    let response = client
-        .post(url)
-        .headers(custom_header)
-        .json(&data)
-        .send()
-        .await
-        .map_err(HeatzyCallError::Request)?;
-
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        Err(HeatzyCallError::HttpStatus(response.status()))
-    }
-}
-
-async fn login_heatzy(
-    heatzy_application_id: &str,
-    heatzy_username: &str,
-    heatzy_password: &str,
-) -> anyhow::Result<String> {
-    let url = "https://api.gizwits.com/app/login";
-    let body = serde_json::json!({
-        "username": heatzy_username,
-        "password": heatzy_password,
-    });
-
-    let mut custom_header = header::HeaderMap::new();
-    custom_header.insert(
-        header::USER_AGENT,
-        header::HeaderValue::from_static("reqwest"),
-    );
-    custom_header.insert(
-        header::CONTENT_TYPE,
-        header::HeaderValue::from_static("application/json"),
-    );
-    custom_header.insert(
-        "X-Gizwits-Application-Id",
-        heatzy_application_id.parse().unwrap(),
-    );
-
-    #[derive(Debug, Deserialize)]
-    struct LoginResponse {
-        token: String,
-    }
-
-    let client = reqwest::Client::new();
-    let response = client
-        .post(url)
-        .headers(custom_header)
-        .json(&body)
-        .send()
-        .await?;
-
-    if !response.status().is_success() {
-        return Err(anyhow!(
-            "Heatzy login failed with status {}",
-            response.status()
-        ));
-    }
-
-    let login_response: LoginResponse = response.json().await?;
-    Ok(login_response.token)
-}
-
-fn is_auth_error(status: reqwest::StatusCode) -> bool {
-    status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
-}
-
-enum HeatzyCallError {
-    Request(reqwest::Error),
-    HttpStatus(reqwest::StatusCode),
-}
-
-impl std::fmt::Display for HeatzyCallError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            HeatzyCallError::Request(e) => write!(f, "request error: {}", e),
-            HeatzyCallError::HttpStatus(status) => write!(f, "status {}", status),
-        }
-    }
+    Ok(())
 }
 
 /// Hysteresis copied from existing regulator logic.

--- a/radiator-api/src/main.rs
+++ b/radiator-api/src/main.rs
@@ -7,6 +7,7 @@ use axum::Router;
 use common_config::conf_reader::{read_config, read_env};
 use common_config::properties::{get_prop_pg_connect_string, get_prop_value, set_prop_values};
 use log::{error, info};
+use std::sync::{Arc, RwLock};
 
 mod api;
 
@@ -49,7 +50,9 @@ async fn main() {
     let app_state = api::AppState {
         db_url,
         heatzy_application_id: read_props_or_die("heatzy.application.id"),
-        heatzy_token: read_props_or_die("heatzy.token"),
+        heatzy_token: Arc::new(RwLock::new(read_props_or_die("heatzy.token"))),
+        heatzy_username: read_props_or_die("heatzy.username"),
+        heatzy_password: read_props_or_die("heatzy.password"),
     };
 
     // 4) Start HTTP server with a single business endpoint.

--- a/radiator-ctrl/Cargo.toml
+++ b/radiator-ctrl/Cargo.toml
@@ -20,5 +20,4 @@ serde_derive = { workspace = true }
 
 ava-toolkit = {path="../ava-toolkit"}
 common-config = {path ="../common-config"}
-
-reqwest = { version = "0.11.23", features = ["json"] }
+radiator-toolkit = { path = "../radiator-toolkit" }

--- a/radiator-ctrl/src/message_enum.rs
+++ b/radiator-ctrl/src/message_enum.rs
@@ -1,14 +1,13 @@
 use std::collections::HashMap;
 
-use anyhow::anyhow;
 use lazy_static::lazy_static;
 use log::{error, info};
-use reqwest::header;
-
-use serde_derive::{Deserialize, Serialize};
 use ava_toolkit::device_message::{RegulatorRadiatorMsg, RadiatorMode};
 use ava_toolkit::generic_device::{GenericDevice, Locality, EXTERNAL_FAMILY};
-use common_config::properties::get_prop_value;
+use common_config::properties::{get_prop_value, set_prop_value};
+use radiator_toolkit::HeatzyClient;
+use serde_derive::{Deserialize, Serialize};
+use std::sync::{Arc, RwLock};
 use crate::message_enum::MessageEnum::RegulatorRadiator;
 
 /// Object by enums
@@ -108,76 +107,58 @@ lazy_static! {
             "mO7E2B49G1BS8R77UmWIjk"
         ),
     ]);
+    static ref HEATZY_TOKEN: Arc<RwLock<String>> = Arc::new(RwLock::new(
+        get_prop_value("heatzy.token").expect("Cannot read heatzy.token")
+    ));
 }
 
 // TODO : we could remove the args param all along the cascade of routines
 pub (crate) async fn command_radiator(topic: &str, msg: &RegulatorRadiatorMsg, _args: &[String]) {
     info!("Command [{}]", &topic);
 
-    // let heatzy_pass = args.get(1).unwrap();
-    let heatzy_pass = get_prop_value("heatzy.pass").unwrap(); // TODO
-    // let heatzy_application_id= args.get(2).unwrap();
+    let heatzy_username = get_prop_value("heatzy.username").unwrap();
+    let heatzy_password = get_prop_value("heatzy.password").unwrap();
     let heatzy_application_id = get_prop_value("heatzy.application.id").unwrap();
-    // let heatzy_token= args.get(3).unwrap(); // "74067d76317946fca0433f684cf1e0a1"
-    let heatzy_token= get_prop_value("heatzy.token").unwrap();
 
     let did = DEVICE_DID.get(topic).unwrap();
-    set_mode(&msg.mode, &heatzy_application_id,  &heatzy_pass, &heatzy_token, &did).await;
-    info!("Radiator status changed!");
+    match set_mode(
+        &msg.mode,
+        &heatzy_application_id,
+        &heatzy_username,
+        &heatzy_password,
+        did,
+    )
+    .await
+    {
+        Ok(()) => info!("Radiator status changed!"),
+        Err(e) => error!("Erreur lors de la requête : {}", e),
+    }
 }
 
 
 ///  Les modes sont  0 CONFORT,  1 ECO, 2 HORS GEL, 3 OFF
-async fn set_mode(mode: &RadiatorMode, heatzy_application_id: &str, _heatzy_pass: &str, heatzy_token: &str, did: &str) {
+async fn set_mode(
+    mode: &RadiatorMode,
+    heatzy_application_id: &str,
+    heatzy_username: &str,
+    heatzy_password: &str,
+    did: &str,
+) -> anyhow::Result<()> {
+    let client = HeatzyClient::new(
+        heatzy_application_id,
+        heatzy_username,
+        heatzy_password,
+        HEATZY_TOKEN.clone(),
+    );
+    let previous_token = client.current_token()?;
 
-    let h_mode = match mode {
-        RadiatorMode::CFT => 0,
-        RadiatorMode::ECO => 1,
-        RadiatorMode::FRO => 2,
-        RadiatorMode::STOP => 3,
-    };
+    client.set_mode(did, *mode).await?;
 
-    let data = serde_json::json!({
-         "attrs": {
-            "mode": h_mode
-         }
-    });
-
-    let url = format!("https://euapi.gizwits.com/app/control/{}", did); // device did
-
-    let mut custom_header = header::HeaderMap::new();
-    custom_header.insert(header::USER_AGENT, header::HeaderValue::from_static("reqwest"));
-    custom_header.insert(header::CONTENT_TYPE, header::HeaderValue::from_static("application/json"));
-    custom_header.insert("X-Gizwits-Application-Id", heatzy_application_id.parse().unwrap());
-    custom_header.insert("X-Gizwits-User-token", heatzy_token.parse().unwrap());
-
-    match post_data(&url, data, custom_header).await {
-        Ok(response) => {
-            info!("Réponse: {}", response);
-        }
-        Err(e) => {
-            error!("Erreur lors de la requête : {}", e);
-        }
+    let current_token = client.current_token()?;
+    if current_token != previous_token {
+        set_prop_value("heatzy.token", &current_token);
+        info!("Heatzy token refreshed and saved into runtime configuration");
     }
-}
-
-async fn post_data(url: &str, data: serde_json::Value, headers: header::HeaderMap) -> anyhow::Result<String> {
-    // Créer une nouvelle session Reqwest
-    let client = reqwest::Client::new();
-
-    // Effectuer la requête POST
-    let response = client.post(url)
-        .headers(headers)
-        .json(&data)
-        .send()
-        .await?;
-
-    // Vérifier la réponse HTTP
-    if response.status().is_success() {
-        // Récupérer le corps de la réponse comme chaîne de caractères
-        let body = response.text().await?;
-        Ok(body)
-    } else {
-        Err(anyhow!("{:?}", response))
-    }
+    info!("Commande radiateur envoyée avec succès");
+    Ok(())
 }

--- a/radiator-toolkit/Cargo.toml
+++ b/radiator-toolkit/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "radiator-toolkit"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+ava-toolkit = { path = "../ava-toolkit" }

--- a/radiator-toolkit/src/lib.rs
+++ b/radiator-toolkit/src/lib.rs
@@ -1,0 +1,219 @@
+use std::sync::{Arc, RwLock};
+
+use anyhow::anyhow;
+use ava_toolkit::device_message::RadiatorMode;
+use log::info;
+use reqwest::header;
+use serde::Deserialize;
+
+#[derive(Clone, Debug)]
+pub struct HeatzyClient {
+    application_id: String,
+    username: String,
+    password: String,
+    token: Arc<RwLock<String>>,
+}
+
+impl HeatzyClient {
+    pub fn new(
+        application_id: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+        token: Arc<RwLock<String>>,
+    ) -> Self {
+        Self {
+            application_id: application_id.into(),
+            username: username.into(),
+            password: password.into(),
+            token,
+        }
+    }
+
+    pub fn current_token(&self) -> anyhow::Result<String> {
+        let guard = self
+            .token
+            .read()
+            .map_err(|_| anyhow!("Cannot read current Heatzy token"))?;
+        Ok(guard.clone())
+    }
+
+    pub async fn set_mode(&self, did: &str, mode: RadiatorMode) -> anyhow::Result<()> {
+        let current_token = self.current_token()?;
+
+        info!("Using existing Heatzy token for control API call");
+        match self
+            .set_mode_with_token(&current_token, did, mode)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(HeatzyCallError::HttpStatus { status, body }) if status.is_client_error() => {
+                info!("🔄 Reconnecting to Heatzy to refresh token");
+                info!(
+                    "Heatzy token rejected with status {} and body [{}], trying login before retrying command",
+                    status, body
+                );
+                let refreshed_token = self.login().await?;
+
+                {
+                    let mut guard = self
+                        .token
+                        .write()
+                        .map_err(|_| anyhow!("Cannot update Heatzy token"))?;
+                    *guard = refreshed_token.clone();
+                }
+                info!("Heatzy token refreshed in memory");
+
+                self.set_mode_with_token(&refreshed_token, did, mode)
+                    .await
+                    .map_err(|e| anyhow!("Heatzy error after relogin: {}", e))
+            }
+            Err(e) => Err(anyhow!("Heatzy error: {}", e)),
+        }
+    }
+
+    async fn set_mode_with_token(
+        &self,
+        heatzy_token: &str,
+        did: &str,
+        mode: RadiatorMode,
+    ) -> Result<(), HeatzyCallError> {
+        let h_mode = match mode {
+            RadiatorMode::CFT => 0,
+            RadiatorMode::ECO => 1,
+            RadiatorMode::FRO => 2,
+            RadiatorMode::STOP => 3,
+        };
+
+        let data = serde_json::json!({
+            "attrs": {
+                "mode": h_mode
+            }
+        });
+
+        let url = format!("https://euapi.gizwits.com/app/control/{}", did);
+
+        let mut custom_header = header::HeaderMap::new();
+        custom_header.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_static("reqwest"),
+        );
+        custom_header.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        custom_header.insert(
+            "X-Gizwits-Application-Id",
+            self.application_id.parse().unwrap(),
+        );
+        custom_header.insert("X-Gizwits-User-token", heatzy_token.parse().unwrap());
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(url)
+            .headers(custom_header)
+            .json(&data)
+            .send()
+            .await
+            .map_err(HeatzyCallError::Request)?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable response body>".to_string());
+            Err(HeatzyCallError::HttpStatus {
+                status,
+                body: body.trim().to_string(),
+            })
+        }
+    }
+
+    async fn login(&self) -> anyhow::Result<String> {
+        let url = "https://euapi.gizwits.com/app/login";
+        let body = serde_json::json!({
+            "username": self.username,
+            "password": self.password,
+        });
+        let redacted_body = serde_json::json!({
+            "username": self.username,
+            "password": "***",
+        });
+
+        let mut custom_header = header::HeaderMap::new();
+        custom_header.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_static("reqwest"),
+        );
+        custom_header.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        custom_header.insert(
+            "X-Gizwits-Application-Id",
+            self.application_id.parse().unwrap(),
+        );
+
+        info!("🔐 Heatzy relogin request");
+        info!("Heatzy relogin URL: {}", url);
+        info!(
+            "Heatzy relogin headers: User-Agent=reqwest, Content-Type=application/json, X-Gizwits-Application-Id={}",
+            self.application_id
+        );
+        info!("Heatzy relogin body: {}", redacted_body);
+
+        #[derive(Debug, Deserialize)]
+        struct LoginResponse {
+            token: String,
+        }
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(url)
+            .headers(custom_header)
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let response_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable response body>".to_string());
+            return Err(anyhow!(
+                "Heatzy login failed with status {} body {}",
+                status,
+                response_body.trim()
+            ));
+        }
+
+        let login_response: LoginResponse = response.json().await?;
+        Ok(login_response.token)
+    }
+}
+
+enum HeatzyCallError {
+    Request(reqwest::Error),
+    HttpStatus {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+}
+
+impl std::fmt::Display for HeatzyCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HeatzyCallError::Request(e) => write!(f, "request error: {}", e),
+            HeatzyCallError::HttpStatus { status, body } => {
+                if body.is_empty() {
+                    write!(f, "status {}", status)
+                } else {
+                    write!(f, "status {} body {}", status, body)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure radiator control calls recover from expired or rejected Heatzy user tokens by re-authenticating and persisting a refreshed token at runtime.

### Description
- Change `AppState` to store `heatzy_token` as `Arc<RwLock<String>>` and add `heatzy_username` and `heatzy_password` for login credentials.
- Update `set_heatzy_mode` to attempt the control call with the current token, detect auth errors, perform `login_heatzy` to obtain a new token, update the in-memory token via the `RwLock`, persist it with `set_prop_value("heatzy.token", ...)`, and retry the control call.
- Extracted `set_heatzy_mode_with_token` to perform a request using a concrete token and added `login_heatzy`, `is_auth_error`, and `HeatzyCallError` utilities to model request vs HTTP-status failures.
- Adjusted several log messages and request error mapping to use the new error types and token refresh flow.

### Testing
- Built the project with `cargo build` which completed successfully.
- Ran the test suite with `cargo test` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca51b907cc832da61520066c9d1610)